### PR TITLE
✨ feat(review): 리뷰 카드에 그룹명·하위그룹명 표시 및 음식점 상세에서 링크 지원

### DIFF
--- a/src/entities/review/api/reviewApi.ts
+++ b/src/entities/review/api/reviewApi.ts
@@ -12,6 +12,10 @@ import type {
 
 type BackendReviewListItem = {
   id: number
+  groupId?: number | null
+  subgroupId?: number | null
+  groupName?: string | null
+  subgroupName?: string | null
   author?: { nickname?: string | null } | null
   contentPreview?: string | null
   content?: string | null
@@ -69,6 +73,10 @@ const normalizeReviewListResponse = (
 
   const items = (payload.items ?? []).map<ReviewListItemDto>((item) => ({
     id: item.id,
+    groupId: item.groupId ?? undefined,
+    subgroupId: item.subgroupId ?? undefined,
+    groupName: item.groupName ?? undefined,
+    subgroupName: item.subgroupName ?? undefined,
     author: { nickname: item.author?.nickname ?? '알 수 없음' },
     contentPreview: item.contentPreview ?? item.content ?? '',
     isRecommended: Boolean(item.isRecommended),

--- a/src/entities/review/model/dto.ts
+++ b/src/entities/review/model/dto.ts
@@ -4,6 +4,10 @@ import type { CursorPageResponse } from '@/shared/types/pagination'
 
 export type ReviewListItemDto = {
   id: number
+  groupId?: number
+  subgroupId?: number | null
+  groupName?: string
+  subgroupName?: string | null
   author: {
     nickname: string
   }

--- a/src/entities/review/ui/ReviewCard.tsx
+++ b/src/entities/review/ui/ReviewCard.tsx
@@ -1,12 +1,16 @@
 import { ThumbsUp, ThumbsDown } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar'
 import { Card } from '@/shared/ui/card'
 import { Badge } from '@/shared/ui/badge'
 import { cn } from '@/shared/lib/utils'
+import { ROUTES } from '@/shared/config/routes'
 import type { ReviewListItemDto, ReviewDetailDto } from '../model/dto'
 
 type ReviewDtoProps = {
   review: ReviewListItemDto | ReviewDetailDto
+  /** 음식점 상세 페이지에서만 true. true일 때 그룹/하위그룹명을 링크로 표시 */
+  enableGroupLinks?: boolean
   className?: string
 }
 
@@ -93,11 +97,46 @@ export function ReviewCard(props: ReviewCardProps) {
     )
   }
 
-  const { review, className } = props
+  const { review, enableGroupLinks = false, className } = props
   const images = getImages(review)
+
+  const groupName =
+    'groupName' in review && review.groupName != null && review.groupName !== ''
+      ? review.groupName
+      : null
+  const subgroupName =
+    'subgroupName' in review && review.subgroupName != null && review.subgroupName !== ''
+      ? review.subgroupName
+      : null
+  const groupId = 'groupId' in review ? review.groupId : undefined
+  const subgroupId = 'subgroupId' in review ? review.subgroupId : undefined
+  const hasGroupInfo = groupName != null
 
   return (
     <Card className={cn('p-4 gap-0', className)}>
+      {hasGroupInfo && (
+        <p className="text-xs text-muted-foreground mb-5 flex flex-wrap items-center gap-x-1 gap-y-0.5">
+          {enableGroupLinks && groupId != null ? (
+            <Link to={ROUTES.groupDetail(String(groupId))} className="hover:text-primary">
+              {groupName}
+            </Link>
+          ) : (
+            <span>{groupName}</span>
+          )}
+          {subgroupName != null && (
+            <>
+              <span className="shrink-0">{' > '}</span>
+              {enableGroupLinks && subgroupId != null ? (
+                <Link to={ROUTES.subgroupDetail(String(subgroupId))} className="hover:text-primary">
+                  {subgroupName}
+                </Link>
+              ) : (
+                <span>{subgroupName}</span>
+              )}
+            </>
+          )}
+        </p>
+      )}
       <div className="flex items-start gap-3 mb-3">
         <Avatar className="h-10 w-10">
           <AvatarFallback>{review.author.nickname.slice(0, 2)}</AvatarFallback>

--- a/src/pages/restaurant-detail/RestaurantDetailPage.tsx
+++ b/src/pages/restaurant-detail/RestaurantDetailPage.tsx
@@ -766,7 +766,9 @@ export function RestaurantDetailPage() {
                   <Skeleton className="h-24 w-full" />
                 </>
               ) : previewReviews.length > 0 ? (
-                previewReviews.map((review) => <ReviewCard key={review.id} review={review} />)
+                previewReviews.map((review) => (
+                  <ReviewCard key={review.id} review={review} enableGroupLinks />
+                ))
               ) : null}
             </div>
 


### PR DESCRIPTION
- ReviewListItemDto에 groupId, subgroupId, groupName, subgroupName 추가
- reviewApi 백엔드 응답 매핑에 그룹/하위그룹 필드 반영
- ReviewCard 최상단에 그룹 > 하위그룹 형식으로 표시 (하위그룹 없으면 제외)
- enableGroupLinks prop 추가, 음식점 상세 페이지에서만 그룹/하위그룹 링크 활성화
- 그룹 영역과 본문 간 간격(mb-5) 적용