### PR TITLE
Perf(home): Splash 3초 딜레이 제거 및 /main 프리패치 적용

### DIFF
--- a/src/app/bootstrap/mainPageCache.ts
+++ b/src/app/bootstrap/mainPageCache.ts
@@ -1,0 +1,37 @@
+import type { MainPageResponseDto } from '@/entities/main'
+
+type CachedMainPage = {
+  data: MainPageResponseDto
+  latitude: number
+  longitude: number
+}
+
+let cache: CachedMainPage | null = null
+
+export const setMainPageCache = (
+  data: MainPageResponseDto,
+  latitude: number,
+  longitude: number,
+) => {
+  cache = { data, latitude, longitude }
+}
+
+// 좌표가 ~1km 이내면 hit → 캐시 소비 후 반환. miss 혹은 좌표 불일치 시 null 반환 후 캐시 삭제.
+const COORD_EPSILON = 0.01
+
+export const getMainPageCache = (
+  latitude: number,
+  longitude: number,
+): MainPageResponseDto | null => {
+  if (!cache) return null
+  const hit =
+    Math.abs(cache.latitude - latitude) < COORD_EPSILON &&
+    Math.abs(cache.longitude - longitude) < COORD_EPSILON
+  const data = hit ? cache.data : null
+  cache = null
+  return data
+}
+
+export const clearMainPageCache = () => {
+  cache = null
+}

--- a/src/app/bootstrap/useBootstrap.ts
+++ b/src/app/bootstrap/useBootstrap.ts
@@ -1,30 +1,23 @@
 import { useEffect, useState } from 'react'
 import { bootstrapApp } from './bootstrap'
+import { getAccessToken } from '@/shared/lib/authToken'
 
-const getInitialReady = () => {
-  const hasSeenSplash = sessionStorage.getItem('app:seen_splash') === 'true'
-  return hasSeenSplash
-}
+const getInitialReady = () => !!getAccessToken()
 
 export const useBootstrap = () => {
   const [isReady, setIsReady] = useState(getInitialReady)
 
   useEffect(() => {
+    if (isReady) return // 토큰 있음 → bootstrap 불필요
+
     let alive = true
-
-    // Ensure bootstrapApp is always called unconditionally on mount.
-    // The `isReady` state will now only reflect the completion of bootstrapping.
     bootstrapApp().then(() => {
-      if (alive) {
-        sessionStorage.setItem('app:seen_splash', 'true')
-        setIsReady(true)
-      }
+      if (alive) setIsReady(true)
     })
-
     return () => {
       alive = false
     }
-  }, []) // Run only once on mount
+  }, [isReady])
 
   return isReady
 }


### PR DESCRIPTION
- bootstrap 시 /refresh + /main 병렬 실행 (Promise.allSettled)
- 3초 강제 딜레이 제거
- mainPageCache 싱글톤으로 /main 응답 캐싱
- 토큰 존재 시 Splash 생략, 홈 즉시 렌더
- HomePage에서 캐시 히트 시 /main 재호출 없이 즉시 렌더