### PR TITLE
[Perf-P0] Google Fonts @import → <link> 비블로킹 처리

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/shared/assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google Fonts: 비블로킹 로드 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Alegreya+SC:wght@700&family=Montserrat:wght@700&display=swap"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Alegreya+SC:wght@700&family=Montserrat:wght@700&display=swap"
+      />
+    </noscript>
     <!-- Pretendard webfont (WOFF/WOFF2). -->
     <link
       rel="stylesheet"

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Alegreya+SC:wght@700&family=Montserrat:wght@700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## 관련 이슈
close #176

## 변경 내용
- `global.css` 상단 `@import url(google fonts)` 제거
- `index.html`에 `preconnect` + `media="print" onload` 패턴으로 이전
- `<noscript>` fallback 추가

## 개선 지표
- **LCP / FCP 개선**: CSS 파싱 → 외부 CSS → 폰트 파일의 3단계 직렬 체인 제거