### PR TITLE
[Perf-P1] 페이지별 Suspense Skeleton fallback 적용

### DIFF
--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -4,6 +4,11 @@ import { RequireAuth } from '@/features/auth/require-auth'
 import { useAuth } from '@/entities/user'
 import { resolvePageContext, useUserActivity } from '@/entities/user-activity'
 import { FEATURE_FLAGS } from '@/shared/config/featureFlags'
+import { GenericPageSkeleton } from '@/shared/ui/generic-page-skeleton'
+import { HomePageSkeleton } from '@/pages/home/ui/HomePageSkeleton'
+import { SearchPageSkeleton } from '@/pages/search/ui/SearchPageSkeleton'
+import { GroupsPageSkeleton } from '@/pages/group/ui/GroupsPageSkeleton'
+import { RestaurantDetailPageSkeleton } from '@/pages/restaurant-detail/ui/RestaurantDetailPageSkeleton'
 
 const HomePage = lazy(() => import('@/pages/home').then((m) => ({ default: m.HomePage })))
 const LoginPage = lazy(() => import('@/pages/login').then((m) => ({ default: m.LoginPage })))
@@ -150,7 +155,7 @@ export function AppRouter({ onOnboardingComplete }: AppRouterProps) {
   return (
     <>
       <ScrollToTop />
-      <Suspense fallback={<div className="min-h-screen bg-background" />}>
+      <Suspense fallback={<GenericPageSkeleton />}>
         <Routes>
           <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
           <Route
@@ -190,16 +195,18 @@ export function AppRouter({ onOnboardingComplete }: AppRouterProps) {
           <Route
             path="/search"
             element={
-              <SearchPage
-                onRestaurantClick={(id, metadata) => {
-                  trackRestaurantClick(id, metadata?.position ?? -1)
-                  navigate(`/restaurants/${id}`, { state: { fromPageKey } })
-                }}
-                onGroupClick={(id, metadata) => {
-                  trackGroupClick(id, metadata?.position ?? -1)
-                  navigate(`/groups/${id}`)
-                }}
-              />
+              <Suspense fallback={<SearchPageSkeleton />}>
+                <SearchPage
+                  onRestaurantClick={(id, metadata) => {
+                    trackRestaurantClick(id, metadata?.position ?? -1)
+                    navigate(`/restaurants/${id}`, { state: { fromPageKey } })
+                  }}
+                  onGroupClick={(id, metadata) => {
+                    trackGroupClick(id, metadata?.position ?? -1)
+                    navigate(`/groups/${id}`)
+                  }}
+                />
+              </Suspense>
             }
           />
 
@@ -240,12 +247,14 @@ export function AppRouter({ onOnboardingComplete }: AppRouterProps) {
           <Route
             path="/groups"
             element={
-              <GroupsPage
-                onGroupClick={(id) => {
-                  trackGroupClick(id, -1)
-                  navigate(`/groups/${id}`)
-                }}
-              />
+              <Suspense fallback={<GroupsPageSkeleton />}>
+                <GroupsPage
+                  onGroupClick={(id) => {
+                    trackGroupClick(id, -1)
+                    navigate(`/groups/${id}`)
+                  }}
+                />
+              </Suspense>
             }
           />
           <Route
@@ -389,7 +398,14 @@ export function AppRouter({ onOnboardingComplete }: AppRouterProps) {
           />
           <Route path="/events/:id" element={<EventDetailPage onBack={() => navigate(-1)} />} />
 
-          <Route path="/restaurants/:id" element={<RestaurantDetailPage />} />
+          <Route
+            path="/restaurants/:id"
+            element={
+              <Suspense fallback={<RestaurantDetailPageSkeleton />}>
+                <RestaurantDetailPage />
+              </Suspense>
+            }
+          />
           <Route
             path="/restaurants/:id/review"
             element={
@@ -421,20 +437,22 @@ export function AppRouter({ onOnboardingComplete }: AppRouterProps) {
           <Route
             path="/"
             element={
-              <HomePage
-                onSearchClick={() => navigate('/search')}
-                onRestaurantClick={(id, metadata) => {
-                  trackRestaurantClick(id, metadata?.position ?? -1)
-                  navigate(`/restaurants/${id}`, { state: { fromPageKey } })
-                }}
-                onGroupClick={(id) => {
-                  trackGroupClick(id, -1)
-                  navigate(`/groups/${id}`)
-                }}
-                onEventClick={(eventId) => {
-                  trackEventClick(eventId, 0)
-                }}
-              />
+              <Suspense fallback={<HomePageSkeleton />}>
+                <HomePage
+                  onSearchClick={() => navigate('/search')}
+                  onRestaurantClick={(id, metadata) => {
+                    trackRestaurantClick(id, metadata?.position ?? -1)
+                    navigate(`/restaurants/${id}`, { state: { fromPageKey } })
+                  }}
+                  onGroupClick={(id) => {
+                    trackGroupClick(id, -1)
+                    navigate(`/groups/${id}`)
+                  }}
+                  onEventClick={(eventId) => {
+                    trackEventClick(eventId, 0)
+                  }}
+                />
+              </Suspense>
             }
           />
           <Route

--- a/src/pages/group/ui/GroupsPageSkeleton.tsx
+++ b/src/pages/group/ui/GroupsPageSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/shared/ui/skeleton'
+
+export function GroupsPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* TopAppBar */}
+      <Skeleton className="h-14 w-full rounded-none" />
+      <div className="flex flex-col gap-3 p-4 pb-20">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+        ))}
+      </div>
+      {/* BottomTabBar */}
+      <Skeleton className="fixed bottom-0 h-16 w-full max-w-[430px] rounded-none" />
+    </div>
+  )
+}

--- a/src/pages/home/ui/HomePageSkeleton.tsx
+++ b/src/pages/home/ui/HomePageSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@/shared/ui/skeleton'
+
+export function HomePageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* LocationHeader */}
+      <Skeleton className="h-14 w-full rounded-none" />
+      <div className="flex flex-col gap-5 p-4 pb-20">
+        {/* 검색창 */}
+        <Skeleton className="h-10 w-full rounded-full" />
+        {/* 섹션 1: 가로 스크롤 카드 */}
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-5 w-32" />
+          <div className="flex gap-3 overflow-hidden">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-48 w-40 shrink-0 rounded-xl" />
+            ))}
+          </div>
+        </div>
+        {/* 섹션 2: 세로 목록 카드 */}
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-5 w-28" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+      {/* BottomTabBar */}
+      <Skeleton className="fixed bottom-0 h-16 w-full max-w-[430px] rounded-none" />
+    </div>
+  )
+}

--- a/src/pages/restaurant-detail/ui/RestaurantDetailPageSkeleton.tsx
+++ b/src/pages/restaurant-detail/ui/RestaurantDetailPageSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '@/shared/ui/skeleton'
+
+export function RestaurantDetailPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* TopAppBar */}
+      <Skeleton className="h-14 w-full rounded-none" />
+      {/* 이미지 캐러셀 */}
+      <Skeleton className="h-60 w-full rounded-none" />
+      <div className="flex flex-col gap-4 p-4">
+        {/* 식당 이름 */}
+        <Skeleton className="h-7 w-48" />
+        {/* 카테고리 */}
+        <Skeleton className="h-4 w-32" />
+        {/* 주소 / 영업시간 */}
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        {/* 탭 */}
+        <Skeleton className="h-10 w-full rounded-lg" />
+        {/* 탭 콘텐츠 */}
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/search/ui/SearchPageSkeleton.tsx
+++ b/src/pages/search/ui/SearchPageSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/shared/ui/skeleton'
+
+export function SearchPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* TopAppBar */}
+      <Skeleton className="h-14 w-full rounded-none" />
+      <div className="flex flex-col gap-3 p-4 pb-20">
+        {/* 검색 입력 */}
+        <Skeleton className="h-10 w-full rounded-full" />
+        {/* 결과 목록 */}
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-xl" />
+        ))}
+      </div>
+      {/* BottomTabBar */}
+      <Skeleton className="fixed bottom-0 h-16 w-full max-w-[430px] rounded-none" />
+    </div>
+  )
+}

--- a/src/shared/ui/generic-page-skeleton.tsx
+++ b/src/shared/ui/generic-page-skeleton.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from './skeleton'
+
+/** 페이지별 Skeleton이 없는 라우트에 사용하는 범용 fallback */
+export function GenericPageSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Skeleton className="h-14 w-full rounded-none" />
+      <div className="flex flex-col gap-3 p-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
close #181

## 변경 내용
- 빈 `<div>` fallback → 레이아웃 구조 모방 Skeleton으로 교체
- 페이지별 Skeleton: `HomePageSkeleton` / `SearchPageSkeleton` / `GroupsPageSkeleton` / `RestaurantDetailPageSkeleton`
- 나머지 페이지: `GenericPageSkeleton` 공통 fallback

## 개선 지표
CLS 개선 (레이아웃 쉬프트 방지), 로딩 UX 향상