### PR TITLE
⚡️ perf(rum): web-vitals → Sentry RUM 연동 (#182)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
+        "web-vitals": "^5.1.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -3167,6 +3168,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
       "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance/node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
@@ -14848,9 +14855,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
+    "web-vitals": "^5.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,12 @@ import App from './App.tsx'
 import { AppProviders } from '@/app/providers/AppProviders'
 import { BrowserRouter } from 'react-router-dom'
 import { initSentry } from '@/shared/lib/sentry'
+import { reportWebVitals } from '@/shared/lib/webVitals'
 import { ErrorPage } from '@/pages/error-page'
 import { ErrorBoundary } from '@/shared/ui/ErrorBoundary'
 
 initSentry()
+reportWebVitals()
 
 createRoot(document.getElementById('root')!).render(
   <BrowserRouter>

--- a/src/shared/lib/sentry.ts
+++ b/src/shared/lib/sentry.ts
@@ -6,6 +6,7 @@ type SentryUser = { id?: string | number; username?: string } | null
 type SentryModule = {
   init: (options: Record<string, unknown>) => void
   captureException: (error: unknown) => void
+  captureEvent: (event: Record<string, unknown>) => void
   setUser: (user: SentryUser) => void
   browserTracingIntegration: () => unknown
   replayIntegration: () => unknown
@@ -48,6 +49,17 @@ export function initSentry() {
       initialized = false
       logger.warn('[sentry] failed to load @sentry/react; continuing without Sentry', error)
     })
+}
+
+export const captureWebVital = (name: string, value: number, rating: string) => {
+  sentryModule?.captureEvent({
+    type: 'transaction',
+    event_id: crypto.randomUUID(),
+    transaction: `web-vitals/${name}`,
+    measurements: { [name.toLowerCase()]: { value, unit: 'millisecond' } },
+    tags: { rating },
+    level: 'info',
+  })
 }
 
 export const captureException = (error: unknown) => {

--- a/src/shared/lib/webVitals.ts
+++ b/src/shared/lib/webVitals.ts
@@ -1,0 +1,10 @@
+import { onCLS, onINP, onLCP, onFCP, onTTFB } from 'web-vitals'
+import { captureWebVital } from './sentry'
+
+export function reportWebVitals() {
+  onCLS(({ name, value, rating }) => captureWebVital(name, value, rating))
+  onINP(({ name, value, rating }) => captureWebVital(name, value, rating))
+  onLCP(({ name, value, rating }) => captureWebVital(name, value, rating))
+  onFCP(({ name, value, rating }) => captureWebVital(name, value, rating))
+  onTTFB(({ name, value, rating }) => captureWebVital(name, value, rating))
+}


### PR DESCRIPTION
## Summary

- `web-vitals` 패키지를 통해 CLS / INP / LCP / FCP / TTFB 실측 Core Web Vitals 수집
- `captureWebVital()` 함수로 Sentry `captureEvent` API를 통해 Performance 패널에 전송
- `sentryModule` 미초기화 시 silent skip — 초기화 타이밍 이슈 없음

close #185


## 변경 파일

| 파일 | 변경 |
|------|------|
| `src/shared/lib/sentry.ts` | `SentryModule`에 `captureEvent` 타입 추가, `captureWebVital()` export |
| `src/shared/lib/webVitals.ts` | **신규** — 5개 지표 리포터 |
| `src/main.tsx` | `initSentry()` 직후 `reportWebVitals()` 호출 |
| `package.json` | `web-vitals` 패키지 추가 |

## Test plan

- [ ] `npm run build` 성공 확인
- [ ] 스테이징 배포 후 Sentry → Performance → Web Vitals 패널에서 CLS/LCP/INP 수신 확인
