### PR TITLE
⚡️ perf(query): TanStack Query 도입 + MemberGroupsProvider 마이그레이션 (#185, #187)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/react": "^10.39.0",
         "@stomp/stompjs": "^7.3.0",
+        "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.2",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
@@ -6159,6 +6160,32 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/react": "^10.39.0",
     "@stomp/stompjs": "^7.3.0",
+    "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.2",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",

--- a/src/app/providers/AppProviders.tsx
+++ b/src/app/providers/AppProviders.tsx
@@ -1,19 +1,23 @@
+import { QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '@/entities/user'
 import { MemberGroupsProvider } from '@/entities/member'
 import { LocationProvider } from '@/entities/location'
 import { FcmProvider } from '@/entities/notification'
 import { UserActivityProvider } from '@/entities/user-activity'
+import { queryClient } from './queryClient'
 
 export const AppProviders = ({ children }: { children: React.ReactNode }) => {
   return (
-    <AuthProvider>
-      <UserActivityProvider>
-        <FcmProvider>
-          <MemberGroupsProvider>
-            <LocationProvider>{children}</LocationProvider>
-          </MemberGroupsProvider>
-        </FcmProvider>
-      </UserActivityProvider>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <UserActivityProvider>
+          <FcmProvider>
+            <MemberGroupsProvider>
+              <LocationProvider>{children}</LocationProvider>
+            </MemberGroupsProvider>
+          </FcmProvider>
+        </UserActivityProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   )
 }

--- a/src/app/providers/queryClient.ts
+++ b/src/app/providers/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/src/entities/member/model/MemberGroupsProvider.tsx
+++ b/src/entities/member/model/MemberGroupsProvider.tsx
@@ -1,81 +1,30 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { MemberGroupsContext } from './memberGroupsContext'
 import type { MemberGroupsContextValue } from './memberGroupsContext'
-import type { MemberGroupSummaryItemDto } from './dto'
+import { memberKeys } from './memberKeys'
 import { getMyGroupSummaries } from '@/entities/member'
 import { useAuth } from '@/entities/user'
 
-const MEMBER_GROUP_SUMMARY_CACHE_KEY = 'member:group-summaries:v1'
-
-const loadSummaryCache = (): MemberGroupSummaryItemDto[] | null => {
-  try {
-    const raw = sessionStorage.getItem(MEMBER_GROUP_SUMMARY_CACHE_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as { summaries?: MemberGroupSummaryItemDto[] }
-    return Array.isArray(parsed?.summaries) ? parsed.summaries : null
-  } catch {
-    return null
-  }
-}
-
-const saveSummaryCache = (summaries: MemberGroupSummaryItemDto[]) => {
-  try {
-    sessionStorage.setItem(
-      MEMBER_GROUP_SUMMARY_CACHE_KEY,
-      JSON.stringify({ summaries, cachedAt: Date.now() }),
-    )
-  } catch {
-    // ignore storage errors
-  }
-}
-
-const clearSummaryCache = () => {
-  try {
-    sessionStorage.removeItem(MEMBER_GROUP_SUMMARY_CACHE_KEY)
-  } catch {
-    // ignore storage errors
-  }
-}
-
 export const MemberGroupsProvider = ({ children }: { children: React.ReactNode }) => {
   const { isAuthenticated } = useAuth()
-  const [summaries, setSummaries] = useState<MemberGroupSummaryItemDto[]>([])
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoaded, setIsLoaded] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
 
-  const refresh = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const data = await getMyGroupSummaries()
-      setSummaries(data)
-      saveSummaryCache(data)
-      setIsLoaded(true)
-    } catch {
-      setIsLoaded(true)
-      setError('Failed to load member groups')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
+  const {
+    data: summaries = [],
+    isLoading,
+    isFetched,
+    error,
+  } = useQuery({
+    queryKey: memberKeys.groupSummaries(),
+    queryFn: getMyGroupSummaries,
+    enabled: isAuthenticated,
+  })
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setSummaries([])
-      setIsLoaded(false)
-      setIsLoading(false)
-      setError(null)
-      clearSummaryCache()
-      return
-    }
-    const cached = loadSummaryCache()
-    if (cached) {
-      setSummaries(cached)
-      setIsLoaded(true)
-    }
-    refresh()
-  }, [isAuthenticated, refresh])
+  const refresh = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: memberKeys.groupSummaries() }),
+    [queryClient],
+  )
 
   const subgroupIdSet = useMemo(() => {
     const set = new Set<number>()
@@ -96,12 +45,12 @@ export const MemberGroupsProvider = ({ children }: { children: React.ReactNode }
     () => ({
       summaries,
       isLoading,
-      isLoaded,
-      error,
+      isLoaded: isFetched,
+      error: error ? String(error) : null,
       isSubgroupMember,
       refresh,
     }),
-    [summaries, isLoading, isLoaded, error, isSubgroupMember, refresh],
+    [summaries, isLoading, isFetched, error, isSubgroupMember, refresh],
   )
 
   return <MemberGroupsContext.Provider value={value}>{children}</MemberGroupsContext.Provider>

--- a/src/entities/member/model/memberKeys.ts
+++ b/src/entities/member/model/memberKeys.ts
@@ -1,0 +1,4 @@
+export const memberKeys = {
+  all: ['member'] as const,
+  groupSummaries: () => [...memberKeys.all, 'group-summaries'] as const,
+}

--- a/src/entities/user/model/AuthProvider.tsx
+++ b/src/entities/user/model/AuthProvider.tsx
@@ -14,6 +14,7 @@ import {
 import { logout as logoutApi, refreshAccessToken } from '@/entities/auth'
 import { logger } from '@/shared/lib/logger'
 import { Sentry } from '@/shared/lib/sentry'
+import { queryClient } from '@/app/providers/queryClient'
 
 const extractAccessToken = (data: { data: { accessToken?: string } }) =>
   data.data.accessToken ?? null
@@ -104,6 +105,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         resetLoginRequired()
         setShowLogin(false)
         Sentry.setUser(null)
+        queryClient.clear()
         return true
       },
     }),


### PR DESCRIPTION
## Summary

- `@tanstack/react-query` 도입 — 전역 `QueryClient` 싱글톤(staleTime 5분, gcTime 10분, retry 1)
- `AppProviders`에 `QueryClientProvider` 최상단 추가
- `MemberGroupsProvider`의 수동 sessionStorage 캐시를 React Query 인메모리 캐시로 대체
- 로그아웃 시 `queryClient.clear()` 호출로 캐시 초기화

close #185
close #187 

## 변경 파일

| 파일 | 변경 |
|------|------|
| `src/app/providers/queryClient.ts` | **신규** — QueryClient 싱글톤 |
| `src/app/providers/AppProviders.tsx` | `QueryClientProvider` 최상단 추가 |
| `src/entities/member/model/memberKeys.ts` | **신규** — 쿼리키 팩토리 |
| `src/entities/member/model/MemberGroupsProvider.tsx` | `useQuery` 리팩터링, sessionStorage 헬퍼 3개 제거 |
| `src/entities/user/model/AuthProvider.tsx` | 로그아웃 시 `queryClient.clear()` 추가 |
| `package.json` | `@tanstack/react-query` 추가 |

## Test plan

- [ ] `npm run build` 성공 확인
- [ ] 홈 → 그룹 탭 이동 시 그룹 목록 정상 로드
- [ ] 로그아웃 후 재로그인 시 그룹 데이터 fresh 재요청 확인