### PR TITLE
fix(notification): FCM 푸시 알림 미동작 수정

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
-importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-app-compat.js')
-importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-messaging-compat.js')
+importScripts('https://www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js')
+importScripts('https://www.gstatic.com/firebasejs/10.14.1/firebase-messaging-compat.js')
 
 const normalizeDeepLink = (deepLink) => {
   if (typeof deepLink !== 'string' || !deepLink) return '/'

--- a/src/entities/notification/index.ts
+++ b/src/entities/notification/index.ts
@@ -1,4 +1,5 @@
 export * from './api/notificationApi'
 export { FcmProvider } from './model/FcmProvider'
+export { syncFcmToken } from './model/fcm'
 export type * from './model/dto'
 export type * from './model/types'

--- a/src/pages/notification-settings/NotificationSettingsPage.tsx
+++ b/src/pages/notification-settings/NotificationSettingsPage.tsx
@@ -8,7 +8,11 @@ import { Label } from '@/shared/ui/label'
 import { EmptyState } from '@/widgets/empty-state'
 import { Bell } from 'lucide-react'
 import { FEATURE_FLAGS } from '@/shared/config/featureFlags'
-import { getNotificationPreferences, updateNotificationPreferences } from '@/entities/notification'
+import {
+  getNotificationPreferences,
+  syncFcmToken,
+  updateNotificationPreferences,
+} from '@/entities/notification'
 
 type NotificationChannel = 'PUSH' | 'EMAIL'
 type NotificationType = 'CHAT' | 'SYSTEM' | 'NOTICE'
@@ -106,6 +110,13 @@ export function NotificationSettingsPage({ onBack }: NotificationSettingsPagePro
     setSettings((prev) => ({ ...prev, [key]: nextValue }))
 
     if (key === 'pushEnabled') {
+      if (nextValue) {
+        if (Notification.permission === 'denied') {
+          toast.message('브라우저 설정에서 알림을 허용해주세요')
+        } else {
+          void syncFcmToken()
+        }
+      }
       const items = Object.values(TYPE_BY_SETTING).map((type) => ({
         channel: 'PUSH' as const,
         type,

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowRight, Check, MapPin, Search, ShieldCheck, Soup, Users } from 'lucide-react'
+import { ArrowRight, Bell, Check, MapPin, Search, ShieldCheck, Soup, Users } from 'lucide-react'
+import { toast } from 'sonner'
 import { ROUTES } from '@/shared/config/routes'
 import { TopAppBar } from '@/widgets/top-app-bar'
 import { OnboardingProgressDots, OnboardingStepPanel } from '@/features/groups'
 import { useAppLocation } from '@/entities/location'
 import { searchAll } from '@/entities/search'
 import type { SearchGroupItem } from '@/entities/search'
+import { syncFcmToken } from '@/entities/notification'
 import { requestLocationPermission } from '@/shared/lib/geolocation'
 import { cn } from '@/shared/lib/utils'
 import { Badge } from '@/shared/ui/badge'
@@ -21,7 +23,7 @@ type OnboardingPageProps = {
 }
 
 type OnboardingStep = {
-  key: 'location' | 'daily-menu' | 'trusted-review' | 'group-search'
+  key: 'location' | 'notification' | 'daily-menu' | 'trusted-review' | 'group-search'
   title: string
   description: string
   icon: typeof MapPin
@@ -48,6 +50,13 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     description: '',
     icon: MapPin,
     action: '위치 동의하기',
+  },
+  {
+    key: 'notification',
+    title: '알림을 허용하면 더 편리해요.',
+    description: '그룹 활동, 그룹 초대, 맛집 추천 알림을\n실시간으로 받아볼 수 있어요.',
+    icon: Bell,
+    action: '알림 허용하기',
   },
   {
     key: 'daily-menu',
@@ -172,6 +181,13 @@ export function OnboardingPage({ onComplete }: OnboardingPageProps) {
       }
     }
 
+    if (currentStepData.key === 'notification') {
+      await syncFcmToken()
+      if (Notification.permission === 'denied') {
+        toast.message('브라우저 설정에서 알림을 허용하면 푸시 알림을 받을 수 있어요')
+      }
+    }
+
     if (currentStep < ONBOARDING_STEPS.length - 1) {
       setIsTransitioning(true)
       setCurrentStep((prev) => prev + 1)
@@ -249,6 +265,12 @@ export function OnboardingPage({ onComplete }: OnboardingPageProps) {
               {currentStepData.key === 'location' && (
                 <p className="text-muted-foreground -mt-2 text-center text-base whitespace-nowrap">
                   권한을 허용하면 현재 위치 주변의 식당 정보를 제공해드려요.
+                </p>
+              )}
+
+              {currentStepData.key === 'notification' && (
+                <p className="text-muted-foreground -mt-2 text-center text-base">
+                  알림은 언제든지 설정에서 변경할 수 있어요.
                 </p>
               )}
 


### PR DESCRIPTION
## Summary

- 온보딩에 알림 권한 요청 단계 추가 (location → notification → daily-menu → ...)
- 알림 설정 페이지의 pushEnabled 토글 ON 시 `syncFcmToken()` 호출
- Firebase Service Worker SDK 10.8.0 → 10.14.1 버전 업데이트

## Related Issue

close #212

## Test plan

- [ ] 온보딩 진행 → location 단계 후 notification 단계 표시 확인
- [ ] "알림 허용하기" 클릭 → 브라우저 권한 다이얼로그 표시 확인
- [ ] 권한 허용 → `POST /api/v1/members/me/push-notification-targets` 호출 확인 (Network 탭)
- [ ] 권한 거부 → toast 안내 표시 후 다음 단계 진행 가능한지 확인
- [ ] 알림 설정 페이지 → 푸시 알림 허용 토글 ON → 토큰 등록 API 호출 확인
- [ ] 알림 설정 페이지 → 권한 denied 상태에서 토글 ON → 브라우저 설정 안내 toast 확인