### PR TITLE
✨ feat(promotion): 프로모션 화면 이미지를 배너 대신 상세 이미지로 전환

### DIFF
--- a/src/entities/event/api/eventApi.ts
+++ b/src/entities/event/api/eventApi.ts
@@ -22,6 +22,7 @@ type PromotionSummaryResponse = {
   promotionStatus: PromotionStatus
   displayStartAt: string
   displayEndAt: string
+  detailImageUrls?: string[]
 }
 
 type PromotionDetailResponse = {
@@ -53,6 +54,7 @@ const toEventSummary = (promotion: PromotionSummaryResponse): EventDto => ({
   status: toEventStatus(promotion.promotionStatus),
   createdAt: promotion.displayStartAt ?? promotion.promotionStartAt,
   updatedAt: promotion.displayEndAt ?? promotion.promotionEndAt,
+  detailImageUrls: promotion.detailImageUrls,
 })
 
 const toEventDetail = (promotion: PromotionDetailResponse): EventDto => ({

--- a/src/entities/main/model/types.ts
+++ b/src/entities/main/model/types.ts
@@ -44,6 +44,7 @@ export type SplashEventDto = {
   thumbnailImageUrl: string | null
   startAt: IsoDateTimeString
   endAt: IsoDateTimeString
+  detailImageUrls?: string[]
 }
 
 export type MainPageResponseDto = SuccessResponse<{

--- a/src/pages/events/EventDetailPage.tsx
+++ b/src/pages/events/EventDetailPage.tsx
@@ -125,13 +125,17 @@ export function EventDetailPage({ onBack }: EventDetailPageProps) {
           />
         ) : (
           <div className="space-y-6">
-            {event.thumbnailImageUrl && (
-              <div className="relative w-full aspect-[16/9] rounded-lg overflow-hidden">
-                <img
-                  src={event.thumbnailImageUrl}
-                  alt={event.title}
-                  className="w-full h-full object-cover"
-                />
+            {event.detailImageUrls && event.detailImageUrls.length > 0 && (
+              <div className="space-y-3">
+                {event.detailImageUrls.map((imageUrl, index) => (
+                  <div key={index} className="w-full rounded-lg overflow-hidden">
+                    <img
+                      src={imageUrl}
+                      alt={`${event.title} 상세 이미지 ${index + 1}`}
+                      className="w-full h-auto"
+                    />
+                  </div>
+                ))}
               </div>
             )}
 
@@ -153,20 +157,6 @@ export function EventDetailPage({ onBack }: EventDetailPageProps) {
               <div className="prose prose-sm max-w-none">
                 <p className="whitespace-pre-wrap text-foreground">{event.content}</p>
               </div>
-
-              {event.detailImageUrls && event.detailImageUrls.length > 0 && (
-                <div className="space-y-3">
-                  {event.detailImageUrls.map((imageUrl, index) => (
-                    <div key={index} className="w-full rounded-lg overflow-hidden">
-                      <img
-                        src={imageUrl}
-                        alt={`${event.title} 상세 이미지 ${index + 1}`}
-                        className="w-full h-auto"
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           </div>
         )}

--- a/src/pages/events/EventsPage.tsx
+++ b/src/pages/events/EventsPage.tsx
@@ -147,19 +147,19 @@ export function EventsPage({ onBack, onEventClick }: EventsPageProps) {
                 className="cursor-pointer hover:bg-secondary/50 transition-colors overflow-hidden"
                 onClick={() => handleEventClick(event.id, { position: index })}
               >
-                {event.thumbnailImageUrl && (
+                {event.detailImageUrls?.[0] && (
                   <div className="relative w-full aspect-[16/9] overflow-hidden">
                     <img
-                      src={event.thumbnailImageUrl}
+                      src={event.detailImageUrls[0]}
                       alt={event.title}
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-cover object-top"
                     />
                     <div className="absolute top-3 right-3">{getStatusBadge(event.status)}</div>
                   </div>
                 )}
 
                 <div className="p-4 flex items-center gap-3">
-                  {!event.thumbnailImageUrl && (
+                  {!event.detailImageUrls?.[0] && (
                     <div className="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-secondary">
                       <Calendar className="h-5 w-5 text-foreground" />
                     </div>
@@ -168,7 +168,7 @@ export function EventsPage({ onBack, onEventClick }: EventsPageProps) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start gap-2 mb-1">
                       <h4 className="flex-1 truncate text-sm font-medium">{event.title}</h4>
-                      {!event.thumbnailImageUrl && getStatusBadge(event.status)}
+                      {!event.detailImageUrls?.[0] && getStatusBadge(event.status)}
                     </div>
                     <span className="text-xs text-muted-foreground">
                       {formatIsoTimestamp(event.startAt, { preset: 'dotDate' })} ~{' '}

--- a/src/widgets/splash-popup/SplashPopup.tsx
+++ b/src/widgets/splash-popup/SplashPopup.tsx
@@ -1,5 +1,4 @@
 import { X } from 'lucide-react'
-import { useState } from 'react'
 import { Button } from '@/shared/ui/button'
 import type { SplashEventDto } from '@/entities/main'
 
@@ -15,16 +14,14 @@ type SplashPopupProps = {
 }
 
 export function SplashPopup({ event, isOpen, onClose, onLinkClick }: SplashPopupProps) {
-  const [dontShowToday, setDontShowToday] = useState(false)
-
   if (!isOpen) return null
 
   const handleClose = () => {
-    onClose({ dontShowToday })
+    onClose({ dontShowToday: false })
   }
 
   const handleLinkClick = () => {
-    onClose({ dontShowToday })
+    onClose({ dontShowToday: false })
     onLinkClick?.()
   }
 
@@ -42,40 +39,23 @@ export function SplashPopup({ event, isOpen, onClose, onLinkClick }: SplashPopup
           <X className="w-5 h-5 text-white" />
         </button>
 
-        {event.thumbnailImageUrl && (
+        {event.detailImageUrls?.[0] && (
           <div className="relative w-full aspect-[4/3] overflow-hidden">
             <img
-              src={event.thumbnailImageUrl}
+              src={event.detailImageUrls[0]}
               alt={event.title}
               className="w-full h-full object-cover"
             />
           </div>
         )}
 
-        <div className="p-6 space-y-4">
-          <div className="space-y-2">
-            <h3 className="text-center text-lg font-semibold">{event.title}</h3>
-            <p className="text-center text-muted-foreground">{event.content}</p>
-          </div>
-
-          <div className="space-y-2">
-            <Button onClick={handleLinkClick} className="w-full" size="lg">
-              이벤트 보러가기
-            </Button>
-            <Button onClick={handleClose} variant="outline" className="w-full" size="lg">
-              닫기
-            </Button>
-          </div>
-
-          <label className="flex items-center justify-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
-              checked={dontShowToday}
-              onChange={(e) => setDontShowToday(e.target.checked)}
-            />
-            <span className="text-sm text-muted-foreground">오늘 하루 보지 않기</span>
-          </label>
+        <div className="p-4 space-y-2">
+          <Button onClick={handleLinkClick} className="w-full" size="lg">
+            이벤트 보러가기
+          </Button>
+          <Button onClick={handleClose} variant="outline" className="w-full" size="lg">
+            닫기
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- 이벤트 상세 페이지: 배너 이미지 제거, detailImageUrls를 제목/날짜/본문 위에 표시
- 이벤트 리스트: detailImageUrls[0]으로 이미지 소스 변경, object-top 정렬 적용
- 스플래시 팝업: detailImageUrls 사용, 제목/본문/체크박스 제거, 버튼 2개만 유지
- SplashEventDto에 detailImageUrls 타입 필드 추가
- PromotionSummaryResponse 타입에 detailImageUrls 필드 추가 및 toEventSummary 매핑

close #242