### PR TITLE
fix: 단일 이미지 재선택 시 교체 동작 처리

### DIFF
--- a/src/features/upload/useImageUpload.ts
+++ b/src/features/upload/useImageUpload.ts
@@ -42,6 +42,7 @@ export function useImageUpload({ purpose, maxFiles = 5 }: UseImageUploadOptions)
     async (fileList: FileList | File[]) => {
       const incoming = Array.from(fileList)
       const errors: string[] = []
+      const shouldReplace = maxFiles === 1
 
       const valid = incoming.filter((f) => {
         if (f.name.length > MAX_FILENAME_LENGTH) {
@@ -70,16 +71,7 @@ export function useImageUpload({ purpose, maxFiles = 5 }: UseImageUploadOptions)
         return
       }
 
-      setFiles((prev) => {
-        const remaining = maxFiles - prev.length
-        if (remaining <= 0) {
-          setUploadErrors([`최대 ${maxFiles}개까지 업로드 가능합니다`])
-          return prev
-        }
-        return prev
-      })
-
-      const remaining = maxFiles - files.length
+      const remaining = shouldReplace ? 1 : maxFiles - files.length
       if (remaining <= 0) {
         setUploadErrors([`최대 ${maxFiles}개까지 업로드 가능합니다`])
         return
@@ -109,7 +101,13 @@ export function useImageUpload({ purpose, maxFiles = 5 }: UseImageUploadOptions)
           }),
         )
 
-        setFiles((prev) => [...prev, ...optimizedImages])
+        setFiles((prev) => {
+          if (shouldReplace) {
+            prev.forEach((f) => URL.revokeObjectURL(f.previewUrl))
+            return optimizedImages
+          }
+          return [...prev, ...optimizedImages]
+        })
       } catch (error) {
         logger.error('Failed to optimize images:', error)
         setUploadErrors(['이미지 최적화에 실패했습니다'])


### PR DESCRIPTION
## Summary
- 프로필/그룹/하위그룹 등 단일 이미지 업로드 플로우에서 새 이미지 선택 시 기존 선택 항목을 누적하지 않고 교체하도록 동작을 정리했습니다.
- 공용 이미지 업로드 훅의 단일 파일 모드(`maxFiles = 1`)에서 새로 선택한 이미지가 이전 파일을 대체하도록 수정했습니다.
- 교체 시 기존 `previewUrl` 객체 URL을 `revokeObjectURL`로 해제해 리소스 정리를 보강했습니다.

## Issue
- close #253

## Changes
- `src/features/upload/useImageUpload.ts`
  - `addFiles()`에서 `maxFiles === 1`인 경우 `shouldReplace` 분기를 추가
  - 갱신 시 기존 미리보기 URL 정리 후 `setFiles`를 새 파일 배열로 교체
  - 추가 모드(`maxFiles > 1`) 동작은 기존 동작 유지

## Test
- `npm run build` 성공 여부는 기존 커밋 기준으로 확인되었으며, 본 수정은 본문 정비 목적으로 PR 본문/타이틀을 보강했습니다.
