### PR TITLE
refactor: 미사용 음식점 API 래퍼 제거

### DIFF
--- a/src/entities/restaurant/api/restaurantApi.ts
+++ b/src/entities/restaurant/api/restaurantApi.ts
@@ -1,11 +1,8 @@
 import { request } from '@/shared/api/request'
 import { buildQuery } from '@/shared/api/query'
 import type { SuccessResponse } from '@/shared/types/api'
-import type { CursorPageResponse } from '@/shared/types/pagination'
 import type {
   RestaurantDetailResponseDto,
-  RestaurantListResponseDto,
-  RestaurantListItemDto,
   FoodCategoryDto,
   RestaurantCreateRequestDto,
   RestaurantCreateResponseDto,
@@ -20,71 +17,12 @@ export const getRestaurant = (restaurantId: number) =>
     url: `/api/v1/restaurants/${restaurantId}`,
   })
 
-export const getRestaurants = (params: {
-  latitude: number
-  longitude: number
-  cursor?: string
-  size?: number
-  category?: string
-}) =>
-  request<RestaurantListResponseDto>({
-    method: 'GET',
-    url: `/api/v1/restaurants${buildQuery(params)}`,
-  })
-
 export const getFoodCategories = async (): Promise<FoodCategoryDto[]> => {
   const res = await request<SuccessResponse<FoodCategoryDto[]> | FoodCategoryDto[]>({
     method: 'GET',
     url: '/api/v1/food-categories',
   })
   return Array.isArray(res) ? res : res.data
-}
-
-/**
- * 백엔드 mock 응답(`data.items[].thumbnailImages`)을
- * 프론트 DTO(`thumbnailImage`)로 안전하게 변환하는 홈 전용 래퍼.
- */
-type BackendRestaurantListItem = {
-  id: number
-  name: string
-  address: string
-  distanceMeter: number
-  foodCategories: string[]
-  thumbnailImages: { id: number; url: string }[] | null
-}
-
-type BackendRestaurantListResponse = SuccessResponse<CursorPageResponse<BackendRestaurantListItem>>
-
-export const getRestaurantsForHome = async (params: {
-  latitude: number
-  longitude: number
-  cursor?: string
-  size?: number
-  category?: string
-}): Promise<CursorPageResponse<RestaurantListItemDto>> => {
-  const response = await request<BackendRestaurantListResponse>({
-    method: 'GET',
-    url: `/api/v1/restaurants${buildQuery(params)}`,
-  })
-
-  const items = response.data.items.map<RestaurantListItemDto>((item) => {
-    const firstImage = item.thumbnailImages?.[0]
-    return {
-      id: item.id,
-      name: item.name,
-      address: item.address,
-      distanceMeter: item.distanceMeter,
-      foodCategories: item.foodCategories,
-      thumbnailImage: firstImage
-        ? { id: String(firstImage.id), url: firstImage.url }
-        : { id: String(item.id), url: '' },
-    }
-  })
-
-  return {
-    items,
-    pagination: response.data.pagination,
-  }
 }
 
 export const createRestaurant = (payload: RestaurantCreateRequestDto) =>


### PR DESCRIPTION
## Summary
- 사용하지 않는 `getRestaurants`와 `getRestaurantsForHome` 래퍼를 제거했습니다.
- 관련 타입 임포트를 함께 정리했습니다.

## Issue
- close #256

## Changed
- `src/entities/restaurant/api/restaurantApi.ts`에서 미사용 목록 조회 래퍼 제거
- 미사용 타입 및 임포트 정리

## Evidence
- `npm run build`

## Remaining tasks
- n/a