### PR TITLE
refactor: Firebase Messaging 지연 로드 적용

### DIFF
--- a/src/entities/notification/model/FcmProvider.tsx
+++ b/src/entities/notification/model/FcmProvider.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { useAuth } from '@/entities/user'
 import { logger } from '@/shared/lib/logger'
-import { startFcmTokenSync } from './fcm'
 
 export const FcmProvider = ({ children }: { children: React.ReactNode }) => {
   const { isAuthenticated } = useAuth()
@@ -9,15 +8,21 @@ export const FcmProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     if (!isAuthenticated) return
 
+    let isCancelled = false
     let cleanup: (() => void) | undefined
 
-    try {
-      cleanup = startFcmTokenSync()
-    } catch (error) {
-      logger.error('[FcmProvider] Failed to start FCM token sync', error)
-    }
+    void import('./fcm')
+      .then(({ startFcmTokenSync }) => {
+        if (isCancelled) return
+
+        cleanup = startFcmTokenSync()
+      })
+      .catch((error) => {
+        logger.error('[FcmProvider] Failed to start FCM token sync', error)
+      })
 
     return () => {
+      isCancelled = true
       try {
         cleanup?.()
       } catch (error) {

--- a/src/entities/notification/model/fcm.ts
+++ b/src/entities/notification/model/fcm.ts
@@ -1,4 +1,4 @@
-import { getToken, onMessage } from 'firebase/messaging'
+import type { Messaging } from 'firebase/messaging'
 import { toast } from 'sonner'
 import { FIREBASE_VAPID_KEY } from '@/shared/config/env'
 import { logger } from '@/shared/lib/logger'
@@ -12,6 +12,8 @@ const FCM_LAST_SYNC_KEY = 'fcm:token:last-sync:v1'
 const FCM_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000
 let syncInFlight: Promise<void> | null = null
 let serviceWorkerMessageBound = false
+let messagingModulePromise: Promise<typeof import('firebase/messaging')> | null = null
+let foregroundMessageUnsubscribe: (() => void) | null = null
 
 const getStoredToken = () => {
   try {
@@ -48,6 +50,14 @@ const getLastSync = () => {
 
 const canUseNotifications = () =>
   typeof window !== 'undefined' && typeof Notification !== 'undefined'
+
+const loadFirebaseMessagingModule = () => {
+  if (!messagingModulePromise) {
+    messagingModulePromise = import('firebase/messaging')
+  }
+
+  return messagingModulePromise
+}
 
 const isInsideChatRoom = () => {
   if (typeof window === 'undefined') return false
@@ -115,6 +125,7 @@ export const syncFcmToken = async () => {
 
       let token
       try {
+        const { getToken } = await loadFirebaseMessagingModule()
         token = await getToken(messaging, {
           vapidKey: FIREBASE_VAPID_KEY,
           serviceWorkerRegistration: registration,
@@ -146,6 +157,7 @@ export const syncFcmToken = async () => {
         await registerPushNotificationTarget({ deviceId, fcmToken: token })
         setStoredToken(token)
         setLastSync(Date.now())
+        void setupForegroundMessageListener(messaging)
         logger.debug('[fcm] Token registered')
       } catch (error) {
         logger.error('[fcm] Failed to register token with server', error)
@@ -163,15 +175,22 @@ export const syncFcmToken = async () => {
   }
 }
 
-const setupForegroundMessageListener = async () => {
+const setupForegroundMessageListener = async (messagingOverride?: Messaging) => {
   try {
-    const messaging = await getFirebaseMessaging()
+    if (!canUseNotifications() || Notification.permission !== 'granted') {
+      logger.debug('[fcm] Skip foreground listener before permission grant')
+      return
+    }
+    if (foregroundMessageUnsubscribe) return
+
+    const messaging = messagingOverride ?? (await getFirebaseMessaging())
     if (!messaging) {
       logger.debug('[fcm] Messaging unavailable for foreground listener')
       return
     }
 
-    onMessage(messaging, (payload) => {
+    const { onMessage } = await loadFirebaseMessagingModule()
+    foregroundMessageUnsubscribe = onMessage(messaging, (payload) => {
       try {
         logger.debug('[fcm] Foreground message received', payload)
         if (typeof window !== 'undefined') {
@@ -229,6 +248,10 @@ export const startFcmTokenSync = () => {
   }
 
   const scheduleSync = () => {
+    if (canUseNotifications() && Notification.permission === 'granted') {
+      void setupForegroundMessageListener()
+    }
+
     if (shouldSync()) {
       void syncFcmToken()
     }
@@ -248,9 +271,10 @@ export const startFcmTokenSync = () => {
 
   scheduleSync()
   setupServiceWorkerMessageListener()
-  void setupForegroundMessageListener()
 
   return () => {
+    foregroundMessageUnsubscribe?.()
+    foregroundMessageUnsubscribe = null
     window.removeEventListener('visibilitychange', onVisibilityChange)
     window.removeEventListener('focus', scheduleSync)
     window.removeEventListener('online', scheduleSync)

--- a/src/shared/lib/firebase.ts
+++ b/src/shared/lib/firebase.ts
@@ -1,5 +1,5 @@
-import { getApp, getApps, initializeApp, type FirebaseApp } from 'firebase/app'
-import { getMessaging, isSupported, type Messaging } from 'firebase/messaging'
+import type { FirebaseApp } from 'firebase/app'
+import type { Messaging } from 'firebase/messaging'
 import {
   FIREBASE_API_KEY,
   FIREBASE_APP_ID,
@@ -31,12 +31,34 @@ const hasFirebaseConfig = () =>
     FIREBASE_APP_ID,
   )
 
-export const initFirebaseApp = (): FirebaseApp | null => {
+let firebaseAppModulePromise: Promise<typeof import('firebase/app')> | null = null
+let firebaseMessagingModulePromise: Promise<typeof import('firebase/messaging')> | null = null
+
+const loadFirebaseAppModule = () => {
+  if (!firebaseAppModulePromise) {
+    firebaseAppModulePromise = import('firebase/app')
+  }
+
+  return firebaseAppModulePromise
+}
+
+const loadFirebaseMessagingModule = () => {
+  if (!firebaseMessagingModulePromise) {
+    firebaseMessagingModulePromise = import('firebase/messaging')
+  }
+
+  return firebaseMessagingModulePromise
+}
+
+export const initFirebaseApp = async (): Promise<FirebaseApp | null> => {
   try {
     if (!hasFirebaseConfig()) {
       logger.debug('[firebase] Config unavailable')
       return null
     }
+
+    const { getApp, getApps, initializeApp } = await loadFirebaseAppModule()
+
     if (getApps().length > 0) return getApp()
     return initializeApp(firebaseConfig)
   } catch (error) {
@@ -52,13 +74,14 @@ export const getFirebaseMessaging = async (): Promise<Messaging | null> => {
       return null
     }
 
+    const { getMessaging, isSupported } = await loadFirebaseMessagingModule()
     const supported = await isSupported()
     if (!supported) {
       logger.debug('[firebase] Messaging not supported in this environment')
       return null
     }
 
-    const app = initFirebaseApp()
+    const app = await initFirebaseApp()
     if (!app) {
       logger.warn('[firebase] Firebase app initialization failed')
       return null


### PR DESCRIPTION
## Summary
- Firebase SDK를 모듈 레벨 정적 import에서 제거하고 실제 사용 시점 dynamic import로 전환했습니다.
- 알림 권한이 허용된 뒤에만 FCM 토큰 발급과 foreground listener 설정이 동작하도록 정리했습니다.
- 인증 이후에만 FCM 동기화 모듈을 로드하도록 `FcmProvider`를 분리했습니다.

## Issue
- close #182

## Changed
- `src/shared/lib/firebase.ts`에서 `firebase/app`, `firebase/messaging`를 지연 로드하도록 변경했습니다.
- `src/entities/notification/model/fcm.ts`에서 `getToken`, `onMessage` 사용 시점에만 Firebase Messaging SDK를 가져오도록 변경했습니다.
- `src/entities/notification/model/FcmProvider.tsx`가 인증 후에만 `./fcm` 모듈을 불러오도록 조정했습니다.

## Verification
- [x] `npm run build`
- [x] `npm run lint` (기존 경고 6건 유지, 신규 오류 없음)
- [x] `dist/index.html` 초기 preload에서 `vendor-firebase` 제거 확인

## Notes
- `ErrorPage` 정적 import 경고와 `vendor-radix` 초기 preload는 `#200` PR에서 별도로 처리했습니다.
