### PR TITLE
refactor: 긴 목록 가상화 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tasteam",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tasteam",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -41,6 +41,7 @@
         "@sentry/react": "^10.39.0",
         "@stomp/stompjs": "^7.3.0",
         "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-virtual": "^3.13.21",
         "axios": "^1.13.2",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
@@ -155,7 +156,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1981,7 +1981,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2732,7 +2731,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2799,7 +2797,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -2815,8 +2812,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -3273,7 +3269,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3842,7 +3837,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6202,6 +6196,33 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.21.tgz",
+      "integrity": "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz",
+      "integrity": "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -6373,7 +6394,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6384,7 +6404,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6462,7 +6481,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -6755,7 +6773,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7264,7 +7281,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8330,8 +8346,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8612,7 +8627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10738,7 +10752,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12000,7 +12013,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12386,7 +12398,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12417,7 +12428,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12430,7 +12440,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14026,7 +14035,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14116,7 +14124,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -14458,7 +14465,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14793,7 +14799,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15224,7 +15229,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15282,7 +15286,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15744,7 +15747,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@sentry/react": "^10.39.0",
     "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-virtual": "^3.13.21",
     "axios": "^1.13.2",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/favorites/FavoritesPage.tsx
+++ b/src/pages/favorites/FavoritesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Heart, LogIn } from 'lucide-react'
 import { toast } from 'sonner'
@@ -23,6 +23,7 @@ import {
 import { favoriteKeys } from '@/entities/favorite/model/favoriteKeys'
 import type { FavoriteTarget, FavoriteTab, FavoriteRestaurantItem } from '@/entities/favorite'
 import { STALE_USER } from '@/shared/lib/queryConstants'
+import { ScrollVirtualizedStack } from '@/shared/ui/ScrollVirtualizedStack'
 
 type FavoritesPageProps = {
   onRestaurantClick?: (id: string) => void
@@ -35,6 +36,7 @@ export function FavoritesPage({ onRestaurantClick }: FavoritesPageProps) {
   const [selectedTab, setSelectedTab] = useState<FavoriteTab>('personal')
   const [selectedSubgroupId, setSelectedSubgroupId] = useState<number | null>(null)
   const [showSubgroupSelector, setShowSubgroupSelector] = useState(false)
+  const favoritesScrollRef = useRef<HTMLDivElement | null>(null)
 
   // 찜 타겟 목록
   const {
@@ -162,48 +164,60 @@ export function FavoritesPage({ onRestaurantClick }: FavoritesPageProps) {
       )}
 
       {/* Content */}
-      <Container className="flex-1 py-4 overflow-auto">
-        {!isAuthenticated ? (
-          <div className="flex min-h-[50vh] items-center justify-center">
+      <div ref={favoritesScrollRef} className="flex-1 overflow-auto">
+        <Container className="py-4">
+          {!isAuthenticated ? (
+            <div className="flex min-h-[50vh] items-center justify-center">
+              <EmptyState
+                icon={LogIn}
+                title="로그인이 필요해요"
+                description="찜 목록을 보려면 로그인해주세요"
+                actionLabel="로그인하기"
+                onAction={() => {
+                  const returnTo = ROUTES.favorites
+                  sessionStorage.setItem('auth:return_to', returnTo)
+                  navigate(ROUTES.login, { state: { returnTo } })
+                }}
+              />
+            </div>
+          ) : isLoading || isLoadingFavorites ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-24 w-full" />
+              ))}
+            </div>
+          ) : error ? (
+            <EmptyState icon={Heart} title="오류가 발생했습니다" description={error} />
+          ) : currentRestaurants.length === 0 ? (
             <EmptyState
-              icon={LogIn}
-              title="로그인이 필요해요"
-              description="찜 목록을 보려면 로그인해주세요"
-              actionLabel="로그인하기"
-              onAction={() => {
-                const returnTo = ROUTES.favorites
-                sessionStorage.setItem('auth:return_to', returnTo)
-                navigate(ROUTES.login, { state: { returnTo } })
+              icon={Heart}
+              title="찜한 맛집이 없습니다"
+              description="마음에 드는 맛집을 찜해보세요!"
+            />
+          ) : (
+            <ScrollVirtualizedStack
+              count={currentRestaurants.length}
+              scrollRef={favoritesScrollRef}
+              estimateSize={132}
+              overscan={5}
+              gap={12}
+              getItemKey={(index) => currentRestaurants[index]?.restaurantId ?? index}
+              renderItem={(index) => {
+                const restaurant = currentRestaurants[index]
+
+                return (
+                  <FavoriteRestaurantCard
+                    key={restaurant.restaurantId}
+                    restaurant={restaurant}
+                    onRemove={(e) => handleRemoveFavorite(restaurant.restaurantId, e)}
+                    onClick={() => onRestaurantClick?.(String(restaurant.restaurantId))}
+                  />
+                )
               }}
             />
-          </div>
-        ) : isLoading || isLoadingFavorites ? (
-          <div className="space-y-3">
-            {[1, 2, 3].map((i) => (
-              <Skeleton key={i} className="h-24 w-full" />
-            ))}
-          </div>
-        ) : error ? (
-          <EmptyState icon={Heart} title="오류가 발생했습니다" description={error} />
-        ) : currentRestaurants.length === 0 ? (
-          <EmptyState
-            icon={Heart}
-            title="찜한 맛집이 없습니다"
-            description="마음에 드는 맛집을 찜해보세요!"
-          />
-        ) : (
-          <div className="space-y-3">
-            {currentRestaurants.map((restaurant) => (
-              <FavoriteRestaurantCard
-                key={restaurant.restaurantId}
-                restaurant={restaurant}
-                onRemove={(e) => handleRemoveFavorite(restaurant.restaurantId, e)}
-                onClick={() => onRestaurantClick?.(String(restaurant.restaurantId))}
-              />
-            ))}
-          </div>
-        )}
-      </Container>
+          )}
+        </Container>
+      </div>
 
       {/* Group Selector Sheet */}
       <SubgroupSelectorSheet

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -18,6 +18,7 @@ import { getGeolocationPermissionState } from '@/shared/lib/geolocation'
 import type { MainPageResponseDto, MainSectionDto, MainSectionItemDto } from '@/entities/main'
 import { toMainPageData } from '@/entities/main'
 import { getMainPageCache } from '@/app/bootstrap/mainPageCache'
+import { WindowVirtualizedStack } from '@/shared/ui/WindowVirtualizedStack'
 
 const SPLASH_POPUP_DISMISSED_DATE_KEY = 'splash-popup-dismissed-date'
 let dismissedSplashEventIdInSession: number | null = null
@@ -256,25 +257,34 @@ export function HomePage({
     }
     return (
       <Container>
-        <div className="space-y-4">
-          {items.map((item: MainSectionItemDto, index) => (
-            <RestaurantCard
-              key={item.restaurantId}
-              name={item.name}
-              foodCategories={item.foodCategories}
-              category={item.category}
-              distance={formatDistanceLabel(item.distanceMeter)}
-              image={item.thumbnailImageUrl}
-              reviewSummary={item.reviewSummary}
-              onClick={() =>
-                onRestaurantClick?.(String(item.restaurantId), {
-                  position: index,
-                  section: section?.type ?? 'UNKNOWN',
-                })
-              }
-            />
-          ))}
-        </div>
+        <WindowVirtualizedStack
+          count={items.length}
+          estimateSize={300}
+          overscan={3}
+          gap={16}
+          getItemKey={(index) => items[index]?.restaurantId ?? index}
+          renderItem={(index) => {
+            const item = items[index]
+
+            return (
+              <RestaurantCard
+                key={item.restaurantId}
+                name={item.name}
+                foodCategories={item.foodCategories}
+                category={item.category}
+                distance={formatDistanceLabel(item.distanceMeter)}
+                image={item.thumbnailImageUrl}
+                reviewSummary={item.reviewSummary}
+                onClick={() =>
+                  onRestaurantClick?.(String(item.restaurantId), {
+                    position: index,
+                    section: section?.type ?? 'UNKNOWN',
+                  })
+                }
+              />
+            )
+          }}
+        />
       </Container>
     )
   }

--- a/src/pages/my-favorites/MyFavoritesPage.tsx
+++ b/src/pages/my-favorites/MyFavoritesPage.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { Heart } from 'lucide-react'
 import { toast } from 'sonner'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -8,6 +9,7 @@ import { RestaurantCard } from '@/entities/restaurant'
 import { getMyFavoriteRestaurants, deleteMyFavoriteRestaurant } from '@/entities/favorite'
 import { favoriteKeys } from '@/entities/favorite/model/favoriteKeys'
 import { STALE_USER } from '@/shared/lib/queryConstants'
+import { ScrollVirtualizedStack } from '@/shared/ui/ScrollVirtualizedStack'
 
 type MyFavoritesPageProps = {
   onRestaurantClick?: (id: string) => void
@@ -16,6 +18,7 @@ type MyFavoritesPageProps = {
 
 export function MyFavoritesPage({ onRestaurantClick, onBack }: MyFavoritesPageProps) {
   const qc = useQueryClient()
+  const favoritesScrollRef = useRef<HTMLDivElement | null>(null)
 
   const { data: favData } = useQuery({
     queryKey: favoriteKeys.myList(),
@@ -54,33 +57,45 @@ export function MyFavoritesPage({ onRestaurantClick, onBack }: MyFavoritesPagePr
     <div className="flex flex-col h-full bg-background min-h-screen">
       <TopAppBar title="찜한 맛집" showBackButton onBack={onBack} />
 
-      <Container className="flex-1 py-4 overflow-auto">
-        {favorites.length > 0 ? (
-          <div className="space-y-3">
-            {favorites.map((restaurant: any) => (
-              <RestaurantCard
-                key={restaurant.id}
-                name={restaurant.name}
-                foodCategories={restaurant.foodCategories}
-                category={restaurant.category}
-                rating={restaurant.rating}
-                reviewCount={restaurant.reviewCount}
-                address={restaurant.address}
-                imageUrl={restaurant.imageUrl}
-                isSaved={true}
-                onSave={() => deleteMutation.mutate(Number(restaurant.id))}
-                onClick={() => onRestaurantClick?.(restaurant.id)}
-              />
-            ))}
-          </div>
-        ) : (
-          <EmptyState
-            icon={Heart}
-            title="찜한 맛집이 없어요"
-            description="마음에 드는 맛집을 찜해보세요"
-          />
-        )}
-      </Container>
+      <div ref={favoritesScrollRef} className="flex-1 overflow-auto">
+        <Container className="py-4">
+          {favorites.length > 0 ? (
+            <ScrollVirtualizedStack
+              count={favorites.length}
+              scrollRef={favoritesScrollRef}
+              estimateSize={280}
+              overscan={5}
+              gap={12}
+              getItemKey={(index) => favorites[index]?.id ?? index}
+              renderItem={(index) => {
+                const restaurant = favorites[index]
+
+                return (
+                  <RestaurantCard
+                    key={restaurant.id}
+                    name={restaurant.name}
+                    foodCategories={restaurant.foodCategories}
+                    category={restaurant.category}
+                    rating={restaurant.rating}
+                    reviewCount={restaurant.reviewCount}
+                    address={restaurant.address}
+                    imageUrl={restaurant.imageUrl}
+                    isSaved={true}
+                    onSave={() => deleteMutation.mutate(Number(restaurant.id))}
+                    onClick={() => onRestaurantClick?.(restaurant.id)}
+                  />
+                )
+              }}
+            />
+          ) : (
+            <EmptyState
+              icon={Heart}
+              title="찜한 맛집이 없어요"
+              description="마음에 드는 맛집을 찜해보세요"
+            />
+          )}
+        </Container>
+      </div>
     </div>
   )
 }

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -26,6 +26,7 @@ import { useRecentSearches } from '@/entities/search'
 import { SearchGroupCarousel } from '@/features/search/SearchGroupCarousel'
 import type { SearchGroupItem, SearchRestaurantItem } from '@/entities/search'
 import { resolvePageContext, useUserActivity } from '@/entities/user-activity'
+import { WindowVirtualizedStack } from '@/shared/ui/WindowVirtualizedStack'
 
 const SEARCH_DEBOUNCE_MS = 700
 const SCROLL_DEBOUNCE_MS = 300
@@ -406,21 +407,32 @@ export function SearchPage({ onRestaurantClick, onGroupClick }: SearchPageProps)
                     <Container className="space-y-3">
                       <h3 className="text-sm font-semibold">연관 음식점</h3>
                       {hasRestaurantResults ? (
-                        restaurantResults.map((restaurant, index) => (
-                          <RestaurantCard
-                            key={restaurant.restaurantId}
-                            name={restaurant.name}
-                            address={restaurant.address}
-                            foodCategories={restaurant.foodCategories}
-                            category={restaurant.category}
-                            image={restaurant.imageUrl}
-                            onClick={() =>
-                              onRestaurantClick?.(String(restaurant.restaurantId), {
-                                position: index,
-                              })
-                            }
-                          />
-                        ))
+                        <WindowVirtualizedStack
+                          count={restaurantResults.length}
+                          estimateSize={280}
+                          overscan={4}
+                          gap={12}
+                          getItemKey={(index) => restaurantResults[index]?.restaurantId ?? index}
+                          renderItem={(index) => {
+                            const restaurant = restaurantResults[index]
+
+                            return (
+                              <RestaurantCard
+                                key={restaurant.restaurantId}
+                                name={restaurant.name}
+                                address={restaurant.address}
+                                foodCategories={restaurant.foodCategories}
+                                category={restaurant.category}
+                                image={restaurant.imageUrl}
+                                onClick={() =>
+                                  onRestaurantClick?.(String(restaurant.restaurantId), {
+                                    position: index,
+                                  })
+                                }
+                              />
+                            )
+                          }}
+                        />
                       ) : (
                         <p className="text-sm text-muted-foreground py-6 text-center">
                           음식점 검색 결과가 없습니다

--- a/src/shared/ui/ScrollVirtualizedStack.tsx
+++ b/src/shared/ui/ScrollVirtualizedStack.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable react-hooks/incompatible-library */
+
+import type { Key, ReactNode, RefObject } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+type ScrollVirtualizedStackProps = {
+  count: number
+  estimateSize: number
+  scrollRef: RefObject<HTMLElement | null>
+  overscan?: number
+  gap?: number
+  getItemKey?: (index: number) => Key
+  renderItem: (index: number) => ReactNode
+}
+
+export function ScrollVirtualizedStack({
+  count,
+  estimateSize,
+  scrollRef,
+  overscan = 4,
+  gap = 0,
+  getItemKey,
+  renderItem,
+}: ScrollVirtualizedStackProps) {
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+    getItemKey,
+  })
+
+  return (
+    <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative', width: '100%' }}>
+      {virtualizer.getVirtualItems().map((virtualItem) => (
+        <div
+          key={virtualItem.key}
+          data-index={virtualItem.index}
+          ref={virtualizer.measureElement}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${virtualItem.start}px)`,
+          }}
+        >
+          <div
+            style={
+              gap > 0 && virtualItem.index < count - 1 ? { paddingBottom: `${gap}px` } : undefined
+            }
+          >
+            {renderItem(virtualItem.index)}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/shared/ui/WindowVirtualizedStack.tsx
+++ b/src/shared/ui/WindowVirtualizedStack.tsx
@@ -1,0 +1,78 @@
+import type { Key, ReactNode } from 'react'
+import { useLayoutEffect, useState } from 'react'
+import { useWindowVirtualizer } from '@tanstack/react-virtual'
+
+type WindowVirtualizedStackProps = {
+  count: number
+  estimateSize: number
+  overscan?: number
+  gap?: number
+  getItemKey?: (index: number) => Key
+  renderItem: (index: number) => ReactNode
+}
+
+export function WindowVirtualizedStack({
+  count,
+  estimateSize,
+  overscan = 4,
+  gap = 0,
+  getItemKey,
+  renderItem,
+}: WindowVirtualizedStackProps) {
+  const [containerElement, setContainerElement] = useState<HTMLDivElement | null>(null)
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!containerElement) return
+
+    const updateScrollMargin = () => {
+      setScrollMargin(containerElement.offsetTop)
+    }
+
+    updateScrollMargin()
+    window.addEventListener('resize', updateScrollMargin)
+
+    return () => {
+      window.removeEventListener('resize', updateScrollMargin)
+    }
+  }, [containerElement])
+
+  const virtualizer = useWindowVirtualizer({
+    count,
+    estimateSize: () => estimateSize,
+    overscan,
+    getItemKey,
+    scrollMargin,
+  })
+
+  return (
+    <div ref={setContainerElement}>
+      <div
+        style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative', width: '100%' }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => (
+          <div
+            key={virtualItem.key}
+            data-index={virtualItem.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualItem.start - scrollMargin}px)`,
+            }}
+          >
+            <div
+              style={
+                gap > 0 && virtualItem.index < count - 1 ? { paddingBottom: `${gap}px` } : undefined
+              }
+            >
+              {renderItem(virtualItem.index)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `@tanstack/react-virtual`을 도입해 긴 목록 렌더링을 가상화했습니다.
- 검색 결과, 홈의 수직 레스토랑 목록, 찜 목록에 맞는 스크롤 기준(window/inner scroll)을 각각 적용했습니다.
- 재사용 가능한 window/scroll 가상화 스택 컴포넌트를 추가했습니다.

## Issue
- close #188

## Changed
- `src/shared/ui/WindowVirtualizedStack.tsx`, `src/shared/ui/ScrollVirtualizedStack.tsx`를 추가했습니다.
- `src/pages/search/SearchPage.tsx`의 음식점 검색 결과를 window 가상화로 전환했습니다.
- `src/pages/home/HomePage.tsx`의 수직 레스토랑 섹션을 window 가상화로 전환했습니다.
- `src/pages/favorites/FavoritesPage.tsx`, `src/pages/my-favorites/MyFavoritesPage.tsx`의 찜 목록을 내부 스크롤 가상화로 전환했습니다.

## Verification
- [x] `npm run build`
- [x] `npm run lint` (기존 경고 6건 유지, 신규 오류 없음)

## Notes
- 브라우저에서 수동 스크롤 체감 검증은 아직 하지 못했습니다.
- `ErrorPage` 정적 import 경고는 별도 이슈 범위에서 계속 남아 있습니다.
