### PR TITLE
refactor: 최적화 이미지 컴포넌트 도입

### DIFF
--- a/src/entities/restaurant/ui/RestaurantCard.tsx
+++ b/src/entities/restaurant/ui/RestaurantCard.tsx
@@ -2,9 +2,9 @@ import { MapPin, Heart, Sparkles } from 'lucide-react'
 import { Card } from '@/shared/ui/card'
 import { Badge } from '@/shared/ui/badge'
 import { Button } from '@/shared/ui/button'
-import { ImageWithFallback } from '@/shared/ui/image-with-fallback'
 import { cn } from '@/shared/lib/utils'
 import type { RestaurantListItemDto, RestaurantDetailDto } from '../model/dto'
+import { OptimizedImage } from '@/shared/ui/OptimizedImage'
 
 type RestaurantDtoProps = {
   restaurant: RestaurantListItemDto | RestaurantDetailDto
@@ -111,17 +111,23 @@ export function RestaurantCard(props: RestaurantCardProps) {
       {images.length > 1 ? (
         <>
           <div className="w-1/2 h-full border-r border-white/10 relative">
-            <ImageWithFallback
+            <OptimizedImage
               src={images[0]}
               alt="restaurant image 1"
+              width={320}
+              height={240}
               className="object-cover w-full h-full"
+              sizes="(max-width: 768px) 50vw, 240px"
             />
           </div>
           <div className="w-1/2 h-full relative">
-            <ImageWithFallback
+            <OptimizedImage
               src={images[1]}
               alt="restaurant image 2"
+              width={320}
+              height={240}
               className="object-cover w-full h-full"
+              sizes="(max-width: 768px) 50vw, 240px"
             />
             {images.length > 2 && (
               <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white font-medium">
@@ -131,10 +137,13 @@ export function RestaurantCard(props: RestaurantCardProps) {
           </div>
         </>
       ) : (
-        <ImageWithFallback
+        <OptimizedImage
           src={images[0] || ''}
           alt="restaurant image"
+          width={640}
+          height={360}
           className="object-cover w-full h-full"
+          sizes="(max-width: 768px) 100vw, 520px"
         />
       )}
     </div>

--- a/src/pages/favorites/components/FavoriteRestaurantCard.tsx
+++ b/src/pages/favorites/components/FavoriteRestaurantCard.tsx
@@ -1,7 +1,7 @@
 import { Heart, MapPin } from 'lucide-react'
 import { Card, CardContent } from '@/shared/ui/card'
-import { ImageWithFallback } from '@/shared/ui/image-with-fallback'
 import type { FavoriteRestaurantItem } from '@/entities/favorite'
+import { OptimizedImage } from '@/shared/ui/OptimizedImage'
 
 type FavoriteRestaurantCardProps = {
   restaurant: FavoriteRestaurantItem
@@ -55,10 +55,13 @@ export function FavoriteRestaurantCard({
           {/* Image */}
           <div className="relative w-24 h-24 flex-shrink-0 rounded-lg overflow-hidden">
             {restaurant.thumbnailUrl ? (
-              <ImageWithFallback
+              <OptimizedImage
                 src={restaurant.thumbnailUrl}
                 alt={restaurant.name}
+                width={96}
+                height={96}
                 className="w-full h-full object-cover"
+                sizes="96px"
               />
             ) : (
               <div className="w-full h-full bg-accent flex items-center justify-center">

--- a/src/shared/ui/OptimizedImage.tsx
+++ b/src/shared/ui/OptimizedImage.tsx
@@ -1,0 +1,104 @@
+import type { ImgHTMLAttributes } from 'react'
+import { useMemo, useState } from 'react'
+import { cn } from '@/shared/lib/utils'
+import { ERROR_IMG_SRC } from './image-with-fallback'
+
+type OptimizedImageProps = Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  'src' | 'alt' | 'width' | 'height'
+> & {
+  src: string
+  alt: string
+  width: number
+  height: number
+  webpSrc?: string
+  fallbackSrc?: string
+  priority?: boolean
+  pictureClassName?: string
+  disableInteraction?: boolean
+}
+
+const resolveWebpSrc = (src?: string) => {
+  if (!src) return null
+
+  if (/\.webp($|\?)/i.test(src)) return src
+
+  try {
+    const url = new URL(src)
+    const format = url.searchParams.get('fm') ?? url.searchParams.get('format')
+
+    if (format?.toLowerCase() === 'webp') {
+      return url.toString()
+    }
+
+    if (url.hostname.includes('images.unsplash.com')) {
+      url.searchParams.set('fm', 'webp')
+      return url.toString()
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function OptimizedImage({
+  src,
+  alt,
+  width,
+  height,
+  webpSrc,
+  fallbackSrc,
+  priority = false,
+  pictureClassName,
+  className,
+  style,
+  disableInteraction = false,
+  loading,
+  fetchPriority,
+  decoding = 'async',
+  onError: onErrorCallback,
+  ...rest
+}: OptimizedImageProps) {
+  const [didError, setDidError] = useState(false)
+  const resolvedWebpSrc = useMemo(() => resolveWebpSrc(webpSrc ?? src), [src, webpSrc])
+  const interactionClassName = disableInteraction ? 'pointer-events-none select-none' : ''
+  const resolvedFallbackSrc = fallbackSrc ?? ERROR_IMG_SRC
+
+  if (!src && !didError) {
+    return (
+      <img
+        src={resolvedFallbackSrc}
+        alt={alt}
+        width={width}
+        height={height}
+        className={cn(className, interactionClassName)}
+        style={style}
+        {...rest}
+      />
+    )
+  }
+
+  return (
+    <picture className={cn('block', pictureClassName)}>
+      {!didError && resolvedWebpSrc ? <source srcSet={resolvedWebpSrc} type="image/webp" /> : null}
+      <img
+        src={didError ? resolvedFallbackSrc : src}
+        alt={alt}
+        width={width}
+        height={height}
+        draggable={!disableInteraction}
+        loading={priority ? 'eager' : (loading ?? 'lazy')}
+        fetchPriority={priority ? 'high' : (fetchPriority ?? 'auto')}
+        decoding={decoding}
+        className={cn(className, interactionClassName)}
+        style={style}
+        onError={(event) => {
+          setDidError(true)
+          onErrorCallback?.(event)
+        }}
+        {...rest}
+      />
+    </picture>
+  )
+}

--- a/src/shared/ui/image-with-fallback.tsx
+++ b/src/shared/ui/image-with-fallback.tsx
@@ -2,7 +2,7 @@ import type { ImgHTMLAttributes } from 'react'
 import { useState } from 'react'
 import { cn } from '@/shared/lib/utils'
 
-const ERROR_IMG_SRC =
+export const ERROR_IMG_SRC =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg=='
 
 type ImageWithFallbackProps = ImgHTMLAttributes<HTMLImageElement> & {

--- a/src/widgets/hero-recommendation/HeroRecommendationCard.tsx
+++ b/src/widgets/hero-recommendation/HeroRecommendationCard.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight } from 'lucide-react'
 import { Card } from '@/shared/ui/card'
 import { Button } from '@/shared/ui/button'
-import { ImageWithFallback } from '@/shared/ui/image-with-fallback'
 import { cn } from '@/shared/lib/utils'
+import { OptimizedImage } from '@/shared/ui/OptimizedImage'
 
 type HeroRecommendationCardProps = {
   title: string
@@ -40,13 +40,14 @@ export function HeroRecommendationCard({
           </Button>
         </div>
         <div className="w-36 relative overflow-hidden shrink-0">
-          <ImageWithFallback
+          <OptimizedImage
             src={image}
             alt={title}
+            width={500}
+            height={330}
             className="object-cover w-full h-full"
-            loading="eager"
-            fetchPriority="high"
-            decoding="async"
+            priority
+            sizes="144px"
           />
         </div>
       </div>

--- a/src/widgets/home-ad-carousel/HomeAdCarousel.tsx
+++ b/src/widgets/home-ad-carousel/HomeAdCarousel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, type TouchEvent } from 'react'
 import { cn } from '@/shared/lib/utils'
-import { ImageWithFallback } from '@/shared/ui/image-with-fallback'
 import type { BannerDto } from '@/entities/banner'
+import { OptimizedImage } from '@/shared/ui/OptimizedImage'
 
 type HomeAdCarouselProps = {
   banners: BannerDto[]
@@ -131,14 +131,15 @@ export function HomeAdCarousel({
               onClick={() => handleBannerClick(banner, index)}
               style={{ backgroundColor: banner.bgColor ?? undefined }}
             >
-              <ImageWithFallback
+              <OptimizedImage
                 src={banner.imageUrl}
                 alt={banner.title ?? `Banner ${index + 1}`}
+                width={1200}
+                height={320}
                 className="w-full h-full object-cover"
                 disableInteraction
-                loading={index === 0 ? 'eager' : 'lazy'}
-                fetchPriority={index === 0 ? 'high' : 'auto'}
-                decoding="async"
+                priority={index === 0}
+                sizes="100vw"
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary
- WebP source, width/height, priority 옵션을 지원하는 `OptimizedImage` 공통 컴포넌트를 추가했습니다.
- 배너, 히어로 카드, 레스토랑 카드, 찜 카드에 `OptimizedImage`를 적용했습니다.
- 기존 fallback placeholder를 공통 재사용할 수 있도록 `image-with-fallback` 자산을 정리했습니다.

## Issue
- close #189

## Changed
- `src/shared/ui/OptimizedImage.tsx`를 추가해 `<picture>` 기반 WebP 우선 렌더와 priority 옵션을 지원했습니다.
- `src/widgets/home-ad-carousel/HomeAdCarousel.tsx`, `src/widgets/hero-recommendation/HeroRecommendationCard.tsx`에 우선순위 이미지 설정을 적용했습니다.
- `src/entities/restaurant/ui/RestaurantCard.tsx`, `src/pages/favorites/components/FavoriteRestaurantCard.tsx`에 width/height 명시 이미지를 적용했습니다.

## Verification
- [x] `npm run build`
- [x] `npm run lint` (기존 경고 6건 유지, 신규 오류 없음)

## Notes
- 백엔드 이미지 URL은 WebP 대체 소스를 항상 보장하지 않아서, 현재는 WebP가 식별 가능한 URL과 Unsplash 계열 URL만 우선 source로 연결했습니다.
