### PR TITLE
feat: 수동 재배포 경로 추가 및 배포 타임아웃 보강

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -13,6 +14,17 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'production' || 'development' }}
 
     steps:
+      - name: Validate deploy branch
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            develop|main) ;;
+            *)
+              echo "Unsupported deploy branch: ${GITHUB_REF_NAME}"
+              echo "Frontend CD supports only develop and main."
+              exit 1
+              ;;
+          esac
+
       # 1. 소스코드 체크아웃
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -102,8 +114,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
-          source: "./deploy-temp/*"
-          target: "/home/${{ secrets.USERNAME }}/frontend/staging/${{ github.ref_name }}/${{ github.run_number }}"
+          timeout: 2m
+          source: './deploy-temp/*'
+          target: '/home/${{ secrets.USERNAME }}/frontend/staging/${{ github.ref_name }}/${{ github.run_number }}'
           strip_components: 1
 
       # 3. 새 release 생성 후 current 심볼릭 링크 전환 (atomic)
@@ -114,6 +127,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             set -euo pipefail
 
@@ -158,12 +172,14 @@ jobs:
       # 4. 실패/중단 포함 staging 잔여물 정리
       - name: Cleanup Staging Directory
         if: always()
+        continue-on-error: true
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             rm -rf "/home/${{ secrets.USERNAME }}/frontend/staging/${{ github.ref_name }}/${{ github.run_number }}"
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -78,8 +78,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
-          source: "./rollback-temp/*"
-          target: "/home/${{ secrets.USERNAME }}/frontend/staging/rollback/${{ inputs.environment }}/${{ inputs.run_number }}"
+          timeout: 2m
+          source: './rollback-temp/*'
+          target: '/home/${{ secrets.USERNAME }}/frontend/staging/rollback/${{ inputs.environment }}/${{ inputs.run_number }}'
           strip_components: 1
 
       # 5. staging -> 새 release 생성 후 current 링크 전환
@@ -90,6 +91,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             set -euo pipefail
 
@@ -133,12 +135,14 @@ jobs:
       # 6. 실패/중단 포함 staging 잔여물 정리
       - name: Cleanup Rollback Staging Directory
         if: always()
+        continue-on-error: true
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             rm -rf "/home/${{ secrets.USERNAME }}/frontend/staging/rollback/${{ inputs.environment }}/${{ inputs.run_number }}"
 

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -61,7 +61,7 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          title: "프론트엔드 스테이징 서버 빌드 실패 💔"
+          title: '프론트엔드 스테이징 서버 빌드 실패 💔'
           description: |
             **결과:** 빌드 실패
             **배포 브랜치:** ${{ steps.metadata.outputs.deploy_ref }}
@@ -77,8 +77,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
-          source: "dist/*"
-          target: "/home/${{ secrets.USERNAME }}/frontend/staging/stg/${{ github.run_number }}"
+          timeout: 2m
+          source: 'dist/*'
+          target: '/home/${{ secrets.USERNAME }}/frontend/staging/stg/${{ github.run_number }}'
           strip_components: 1
 
       - name: Promote Staging to Release
@@ -88,6 +89,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             set -euo pipefail
 
@@ -127,12 +129,14 @@ jobs:
 
       - name: Cleanup Staging Directory
         if: always()
+        continue-on-error: true
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
+          timeout: 2m
           script: |
             rm -rf "/home/${{ secrets.USERNAME }}/frontend/staging/stg/${{ github.run_number }}"
 


### PR DESCRIPTION
## Summary
- Frontend CD 워크플로에 `workflow_dispatch`를 추가해 `main`과 `develop` 브랜치를 GitHub Actions에서 수동 재배포할 수 있도록 했습니다.
- 수동 실행 시 `main`과 `develop` 외 브랜치가 배포되지 않도록 브랜치 검증 단계를 추가했습니다.
- CD, STG, Rollback 워크플로의 SCP/SSH timeout을 `2m`으로 늘리고 cleanup 단계를 `continue-on-error`로 조정했습니다.

## Issue links
- close #264

## Added
- `Frontend CD` 수동 실행 트리거
- 수동 실행 브랜치 검증 단계

## Changed
- 배포 관련 `scp`/`ssh` timeout을 30초 기본값 대신 2분으로 보강
- cleanup 실패가 전체 배포 결과를 과도하게 오염시키지 않도록 조정

## Remaining tasks
- GitHub Actions에서 `Frontend CD`를 `develop` 또는 `main` 대상으로 수동 실행해 실제 서버 연결 상태를 재확인해야 합니다.
- 최근 `develop` 배포 실패는 build가 아니라 서버 전송 단계의 `dial tcp ... i/o timeout`으로 확인됐으므로 서버 네트워크 상태 점검이 필요합니다.

## Checks
- [x] `npx prettier --check .github/workflows/cd.yml .github/workflows/stg-deploy.yml .github/workflows/rollback.yml`
- [x] `git diff --check`
- [ ] 실제 GitHub Actions 수동 배포 실행
