### PR TITLE
refactor(main): 홈/오늘점심 API 호출을 분리 사용 (#266)

### DIFF
--- a/src/app/bootstrap/bootstrap.ts
+++ b/src/app/bootstrap/bootstrap.ts
@@ -1,7 +1,7 @@
 import { request } from '@/shared/api/request'
 import { API_ENDPOINTS } from '@/shared/config/routes'
 import { clearAccessToken, setAccessToken, setRefreshEnabled } from '@/shared/lib/authToken'
-import { getMainPage } from '@/entities/main'
+import { getHomePage } from '@/entities/main'
 import { getCurrentPosition, getLocationPermission } from '@/shared/lib/geolocation'
 import { setMainPageCache, clearMainPageCache } from './mainPageCache'
 
@@ -48,9 +48,9 @@ const runBootstrapTasks = async () => {
   const lat = position?.latitude ?? DEFAULT_LAT
   const lng = position?.longitude ?? DEFAULT_LNG
 
-  const mainResult = await getMainPage({ latitude: lat, longitude: lng }).catch(() => null)
-  if (mainResult) {
-    setMainPageCache(mainResult, lat, lng)
+  const homeResult = await getHomePage({ latitude: lat, longitude: lng }).catch(() => null)
+  if (homeResult) {
+    setMainPageCache(homeResult, lat, lng)
   } else {
     clearMainPageCache()
   }

--- a/src/app/bootstrap/mainPageCache.ts
+++ b/src/app/bootstrap/mainPageCache.ts
@@ -1,7 +1,7 @@
-import type { MainPageResponseDto } from '@/entities/main'
+import type { HomePageResponseDto } from '@/entities/main'
 
 type CachedMainPage = {
-  data: MainPageResponseDto
+  data: HomePageResponseDto
   latitude: number
   longitude: number
 }
@@ -9,7 +9,7 @@ type CachedMainPage = {
 let cache: CachedMainPage | null = null
 
 export const setMainPageCache = (
-  data: MainPageResponseDto,
+  data: HomePageResponseDto,
   latitude: number,
   longitude: number,
 ) => {
@@ -22,7 +22,7 @@ const COORD_EPSILON = 0.0001
 export const getMainPageCache = (
   latitude: number,
   longitude: number,
-): MainPageResponseDto | null => {
+): HomePageResponseDto | null => {
   if (!cache) return null
   const hit =
     Math.abs(cache.latitude - latitude) < COORD_EPSILON &&

--- a/src/entities/main/api/mainApi.ts
+++ b/src/entities/main/api/mainApi.ts
@@ -1,9 +1,26 @@
 import { request } from '@/shared/api/request'
 import { buildQuery } from '@/shared/api/query'
-import type { MainPageQuery, MainPageResponseDto } from '../model/types'
+import type {
+  AiRecommendResponseDto,
+  HomePageResponseDto,
+  MainPageQuery,
+  MainPageResponseDto,
+} from '../model/types'
 
 export const getMainPage = (params: MainPageQuery) =>
   request<MainPageResponseDto>({
     method: 'GET',
     url: `/api/v1/main${buildQuery(params)}`,
+  })
+
+export const getHomePage = (params: MainPageQuery) =>
+  request<HomePageResponseDto>({
+    method: 'GET',
+    url: `/api/v1/main/home${buildQuery(params)}`,
+  })
+
+export const getAiRecommendPage = (params: MainPageQuery) =>
+  request<AiRecommendResponseDto>({
+    method: 'GET',
+    url: `/api/v1/main/ai-recommend${buildQuery(params)}`,
   })

--- a/src/entities/main/model/mapper.ts
+++ b/src/entities/main/model/mapper.ts
@@ -1,5 +1,7 @@
 import type {
   AiRecommendData,
+  AiRecommendResponseDto,
+  HomePageResponseDto,
   MainPageData,
   MainPageResponseDto,
   MainSectionDto,
@@ -16,9 +18,16 @@ export const toMainPageData = (response: MainPageResponseDto | null): MainPageDa
   }
 }
 
-export const toAiRecommendData = (response: MainPageResponseDto | null): AiRecommendData => {
+export const toHomePageData = (response: HomePageResponseDto | null): MainPageData => {
   const sections = response?.data?.sections ?? []
   return {
-    section: sections.find((section) => section.type === 'AI_RECOMMEND') ?? null,
+    sections: filterSectionTypes(sections, ['NEW', 'HOT']),
+  }
+}
+
+export const toAiRecommendData = (response: AiRecommendResponseDto | null): AiRecommendData => {
+  const section = response?.data?.section ?? null
+  return {
+    section,
   }
 }

--- a/src/entities/main/model/types.ts
+++ b/src/entities/main/model/types.ts
@@ -27,7 +27,7 @@ export type MainSectionItemDto = {
   foodCategories: string[]
   category?: string
   thumbnailImageUrl: string
-  isFavorite: boolean
+  isFavorite?: boolean
   reviewSummary: string
 }
 
@@ -51,6 +51,16 @@ export type MainPageResponseDto = SuccessResponse<{
   banners: MainBannerGroupDto
   sections: MainSectionDto[]
   splashPromotion?: SplashEventDto
+}>
+
+export type HomePageResponseDto = SuccessResponse<{
+  banners: MainBannerGroupDto
+  sections: MainSectionDto[]
+  splashPromotion?: SplashEventDto
+}>
+
+export type AiRecommendResponseDto = SuccessResponse<{
+  section: MainSectionDto
 }>
 
 export type MainPageData = {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -11,12 +11,12 @@ import { RestaurantCard } from '@/entities/restaurant'
 import { Input } from '@/shared/ui/input'
 import { Skeleton } from '@/shared/ui/skeleton'
 import { ROUTES } from '@/shared/config/routes'
-import { getMainPage } from '@/entities/main'
+import { getHomePage } from '@/entities/main'
 import type { BannerDto } from '@/entities/banner'
 import { useAppLocation } from '@/entities/location'
 import { getGeolocationPermissionState } from '@/shared/lib/geolocation'
-import type { MainPageResponseDto, MainSectionDto, MainSectionItemDto } from '@/entities/main'
-import { toMainPageData } from '@/entities/main'
+import type { HomePageResponseDto, MainSectionDto, MainSectionItemDto } from '@/entities/main'
+import { toHomePageData } from '@/entities/main'
 import { getMainPageCache } from '@/app/bootstrap/mainPageCache'
 import { WindowVirtualizedStack } from '@/shared/ui/WindowVirtualizedStack'
 
@@ -50,7 +50,7 @@ export function HomePage({
   onSplashSettled,
 }: HomePageProps) {
   const navigate = useNavigate()
-  const [mainData, setMainData] = useState<MainPageResponseDto | null>(null)
+  const [homeData, setHomeData] = useState<HomePageResponseDto | null>(null)
   const [isMainLoading, setIsMainLoading] = useState(true)
   const [hasLoadedMain, setHasLoadedMain] = useState(false)
   const [showSplashPopup, setShowSplashPopup] = useState(false)
@@ -63,7 +63,7 @@ export function HomePage({
     const cached = getMainPageCache(latitude, longitude)
     if (cached) {
       queueMicrotask(() => {
-        setMainData(cached)
+        setHomeData(cached)
         const splashPromotion = cached.data?.splashPromotion
         const willShow = shouldShowSplashPopup(splashPromotion?.id)
         setShowSplashPopup(willShow)
@@ -75,9 +75,9 @@ export function HomePage({
     }
 
     queueMicrotask(() => setIsMainLoading(true))
-    getMainPage({ latitude, longitude })
+    getHomePage({ latitude, longitude })
       .then((data) => {
-        setMainData(data)
+        setHomeData(data)
         const splashPromotion = data.data?.splashPromotion
         const willShow = shouldShowSplashPopup(splashPromotion?.id)
         setShowSplashPopup(willShow)
@@ -106,9 +106,9 @@ export function HomePage({
     })()
   }, [requestCurrentLocation, status])
 
-  const mainPageData = toMainPageData(mainData)
+  const mainPageData = toHomePageData(homeData)
   const banners: BannerDto[] =
-    mainData?.data?.banners?.items?.map((item) => ({
+    homeData?.data?.banners?.items?.map((item) => ({
       id: item.id,
       imageUrl: item.imageUrl,
       title: null,
@@ -118,7 +118,7 @@ export function HomePage({
     })) ?? []
   const sections = mainPageData.sections
   const resolvedSections = sections
-  const splashEvent = mainData?.data?.splashPromotion
+  const splashEvent = homeData?.data?.splashPromotion
 
   const closeSplashPopup = (dontShowToday: boolean) => {
     if (splashEvent?.id) {

--- a/src/pages/today-lunch/TodayLunchPage.tsx
+++ b/src/pages/today-lunch/TodayLunchPage.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, Sparkles } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
 import { Container } from '@/shared/ui/container'
 import { RestaurantCard } from '@/entities/restaurant'
-import { getMainPage } from '@/entities/main'
+import { getAiRecommendPage } from '@/entities/main'
 import { useAppLocation } from '@/entities/location'
 import type { MainSectionItemDto } from '@/entities/main'
 import { toAiRecommendData } from '@/entities/main'
@@ -27,7 +27,7 @@ export function TodayLunchPage({ onBack, onRestaurantClick }: TodayLunchPageProp
       if (active) setIsLoading(true)
     })
 
-    getMainPage({ latitude, longitude })
+    getAiRecommendPage({ latitude, longitude })
       .then((response) => {
         if (!active) return
         const aiRecommend = toAiRecommendData(response).section

--- a/src/shared/api/http.ts
+++ b/src/shared/api/http.ts
@@ -17,6 +17,8 @@ type RefreshResponse = SuccessResponse<{ accessToken?: string }>
 
 const PUBLIC_ENDPOINTS = [
   '/api/v1/main',
+  '/api/v1/main/home',
+  '/api/v1/main/ai-recommend',
   '/api/v1/promotions',
   '/api/v1/announcements',
   '/api/v1/geocode/reverse',


### PR DESCRIPTION
## 변경 요약
- bootstrap 및 HomePage에서 기존 /api/v1/main을 /api/v1/main/home로 전환했습니다.
- HomePage 캐시/응답 매핑은 홈 전용 응답(, , ) 기준으로 정렬했습니다.
- 오늘점심 페이지는 /api/v1/main/ai-recommend 전용 API를 사용하도록 변경했습니다.
- /api/v1/main/home 및 /api/v1/main/ai-recommend를 public API 예외로 허용했습니다.