### PR TITLE
🐛 fix(ui): 레스토랑 카드 이미지 영역 미채움 버그 수정 (#271)

### DIFF
--- a/src/shared/ui/OptimizedImage.tsx
+++ b/src/shared/ui/OptimizedImage.tsx
@@ -80,7 +80,7 @@ export function OptimizedImage({
   }
 
   return (
-    <picture className={cn('block', pictureClassName)}>
+    <picture className={cn('block w-full h-full', pictureClassName)}>
       {!didError && resolvedWebpSrc ? <source srcSet={resolvedWebpSrc} type="image/webp" /> : null}
       <img
         src={didError ? resolvedFallbackSrc : src}


### PR DESCRIPTION
What changed:
- OptimizedImage의 <picture> 태그에 w-full h-full 클래스 추가

Why:
- <picture> 태그가 부모 컨테이너 크기를 채우지 못해 카드 이미지 영역에 빈 공간 발생

Evidence:
- 홈 화면 신규 개장/이번주 Hot 섹션 카드 이미지 정상 표시 확인

Refs: #271