### PR TITLE
🐛 fix(frontend): 모듈 스크립트 MIME 오류 대응 (#271)

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
What changed

- index.html의 type='module' 스크립트 경로를 '/src/main.tsx'에서 './src/main.tsx'로 변경

Why

정적 호스팅에서 서브경로 또는 잘못된 rewrite가 발생하더라도 JS 모듈 경로 해석을 안정화

Evidence

로컬 빌드/프리뷰에서 해당 스크립트 로딩 경로로 인한 MIME 오류가 사라지는지 확인

Refs: #271