### PR TITLE
feat: 위치 고정값을 환경 변수로 설정 가능하게 변경

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 VITE_APP_ENV=local
 VITE_APP_URL=http://localhost:3000
 VITE_API_BASE_URL=http://localhost:8080
+# Format: lat|lng|district|address
+# Leave empty to use the default fixed Pangyo location.
+# Set to off to use the device geolocation again.
+VITE_FIXED_LOCATION=
 VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=

--- a/src/app/bootstrap/bootstrap.ts
+++ b/src/app/bootstrap/bootstrap.ts
@@ -1,4 +1,5 @@
 import { request } from '@/shared/api/request'
+import { DEFAULT_APP_LOCATION } from '@/shared/config/env'
 import { API_ENDPOINTS } from '@/shared/config/routes'
 import { clearAccessToken, setAccessToken, setRefreshEnabled } from '@/shared/lib/authToken'
 import { getHomePage } from '@/entities/main'
@@ -12,8 +13,8 @@ type RefreshResponse = {
   }
 }
 
-const DEFAULT_LAT = 37.5665
-const DEFAULT_LNG = 126.978
+const DEFAULT_LAT = DEFAULT_APP_LOCATION.latitude
+const DEFAULT_LNG = DEFAULT_APP_LOCATION.longitude
 
 const runBootstrapTasks = async () => {
   setRefreshEnabled(true)

--- a/src/entities/location/model/LocationProvider.tsx
+++ b/src/entities/location/model/LocationProvider.tsx
@@ -2,18 +2,30 @@ import { useCallback, useMemo, useState } from 'react'
 import { LocationContext } from './locationContext'
 import type { AppLocation, LocationStatus } from './types'
 import { getCurrentPosition, setLocationPermission } from '@/shared/lib/geolocation'
+import {
+  DEFAULT_APP_LOCATION,
+  FIXED_APP_LOCATION,
+  IS_FIXED_LOCATION_ENABLED,
+} from '@/shared/config/env'
 import { reverseGeocodeNominatim } from '../api/reverseGeocode'
 
 const STORAGE_KEY = 'app_location_v1'
-const DEFAULT_LOCATION: Omit<AppLocation, 'updatedAt' | 'source'> = {
-  // fallback: 경기도 성남시 판교역
-  latitude: 37.3947,
-  longitude: 127.1112,
-  district: '판교역',
-  address: '경기도 성남시 분당구 판교역',
-}
+const DEFAULT_LOCATION: Omit<AppLocation, 'updatedAt' | 'source'> = DEFAULT_APP_LOCATION
+
+const createLocation = (
+  base: Omit<AppLocation, 'updatedAt' | 'source'>,
+  source: AppLocation['source'],
+): AppLocation => ({
+  ...base,
+  updatedAt: new Date().toISOString(),
+  source,
+})
 
 function loadFromStorage(): AppLocation | null {
+  if (FIXED_APP_LOCATION) {
+    return createLocation(FIXED_APP_LOCATION, 'manual')
+  }
+
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     return raw ? (JSON.parse(raw) as AppLocation) : null
@@ -31,20 +43,12 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
   const [location, setLocation] = useState<AppLocation | null>(() => {
     const stored = loadFromStorage()
     if (stored) return stored
-    return {
-      ...DEFAULT_LOCATION,
-      updatedAt: new Date().toISOString(),
-      source: 'manual',
-    }
+    return createLocation(DEFAULT_LOCATION, 'manual')
   })
   const [error, setError] = useState<string | null>(null)
 
   const setManualLocation = useCallback((next: Omit<AppLocation, 'source' | 'updatedAt'>) => {
-    const value: AppLocation = {
-      ...next,
-      updatedAt: new Date().toISOString(),
-      source: 'manual',
-    }
+    const value = createLocation(FIXED_APP_LOCATION ?? next, 'manual')
     setLocation(value)
     saveToStorage(value)
     setError(null)
@@ -53,18 +57,22 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
 
   const clearLocation = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY)
-    setLocation({
-      ...DEFAULT_LOCATION,
-      updatedAt: new Date().toISOString(),
-      source: 'manual',
-    })
+    setLocation(createLocation(DEFAULT_LOCATION, 'manual'))
     setError(null)
-    setStatus('idle')
+    setStatus(IS_FIXED_LOCATION_ENABLED ? 'ready' : 'idle')
   }, [])
 
   const requestCurrentLocation = useCallback(async (): Promise<AppLocation | null> => {
     setStatus('loading')
     setError(null)
+
+    if (FIXED_APP_LOCATION) {
+      const value = createLocation(FIXED_APP_LOCATION, 'manual')
+      setLocation(value)
+      saveToStorage(value)
+      setStatus('ready')
+      return value
+    }
 
     const coords = await getCurrentPosition()
     if (!coords) {
@@ -81,14 +89,15 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
         latitude: coords.latitude,
         longitude: coords.longitude,
       })
-      const value: AppLocation = {
-        latitude: coords.latitude,
-        longitude: coords.longitude,
-        district: resolved.district,
-        address: resolved.address,
-        updatedAt: new Date().toISOString(),
-        source: 'geolocation',
-      }
+      const value = createLocation(
+        {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          district: resolved.district,
+          address: resolved.address,
+        },
+        'geolocation',
+      )
       setLocation(value)
       saveToStorage(value)
       setStatus('ready')
@@ -97,11 +106,7 @@ export function LocationProvider({ children }: { children: React.ReactNode }) {
       setStatus('error')
       setError('주소 정보를 확인할 수 없습니다.')
       setLocation((prev) => {
-        const next = prev ?? {
-          ...DEFAULT_LOCATION,
-          updatedAt: new Date().toISOString(),
-          source: 'manual',
-        }
+        const next = prev ?? createLocation(DEFAULT_LOCATION, 'manual')
         saveToStorage(next)
         return next
       })

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -8,6 +8,7 @@ import { Container } from '@/shared/ui/container'
 import { LocationHeader } from '@/widgets/location-header'
 import { Input } from '@/shared/ui/input'
 import { Skeleton } from '@/shared/ui/skeleton'
+import { DEFAULT_APP_LOCATION } from '@/shared/config/env'
 import { ROUTES } from '@/shared/config/routes'
 import { getHomePage } from '@/entities/main'
 import type { BannerDto } from '@/entities/banner'
@@ -55,8 +56,8 @@ export function HomePage({
   const [showSplashPopup, setShowSplashPopup] = useState(false)
   const { location, status, requestCurrentLocation } = useAppLocation()
   const hasRefreshedRef = useRef(false)
-  const latitude = location?.latitude ?? 37.5665
-  const longitude = location?.longitude ?? 126.978
+  const latitude = location?.latitude ?? DEFAULT_APP_LOCATION.latitude
+  const longitude = location?.longitude ?? DEFAULT_APP_LOCATION.longitude
 
   useEffect(() => {
     const cached = getMainPageCache(latitude, longitude)

--- a/src/pages/today-lunch/TodayLunchPage.tsx
+++ b/src/pages/today-lunch/TodayLunchPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ChevronLeft, Sparkles } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
 import { Container } from '@/shared/ui/container'
+import { DEFAULT_APP_LOCATION } from '@/shared/config/env'
 import { RestaurantCard } from '@/entities/restaurant'
 import { getAiRecommendPage } from '@/entities/main'
 import { useAppLocation } from '@/entities/location'
@@ -17,8 +18,8 @@ export function TodayLunchPage({ onBack, onRestaurantClick }: TodayLunchPageProp
   const [recommendations, setRecommendations] = useState<MainSectionItemDto[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const { location } = useAppLocation()
-  const latitude = location?.latitude ?? 37.5665
-  const longitude = location?.longitude ?? 126.978
+  const latitude = location?.latitude ?? DEFAULT_APP_LOCATION.latitude
+  const longitude = location?.longitude ?? DEFAULT_APP_LOCATION.longitude
 
   useEffect(() => {
     let active = true

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,5 +1,12 @@
 type AppEnv = 'development' | 'staging' | 'production'
 
+export type ConfiguredAppLocation = {
+  latitude: number
+  longitude: number
+  district: string
+  address: string
+}
+
 const getEnv = (key: string, fallback = '') => {
   const value = import.meta.env[key]
   return value ?? fallback
@@ -14,6 +21,44 @@ const getNumberEnv = (key: string, fallback: number) => {
   const value = Number(getEnv(key, String(fallback)))
   return Number.isFinite(value) ? value : fallback
 }
+
+const DEFAULT_APP_LOCATION_VALUE =
+  '37.3947|127.1112|\uD310\uAD50\uC5ED|\uACBD\uAE30\uB3C4 \uC131\uB0A8\uC2DC \uBD84\uB2F9\uAD6C \uD310\uAD50\uC5ED'
+const FIXED_LOCATION_OFF_VALUE = 'off'
+
+const parseConfiguredLocation = (rawValue: string): ConfiguredAppLocation | null => {
+  const [latitudeRaw, longitudeRaw, districtRaw, addressRaw] = rawValue
+    .split('|')
+    .map((value) => value.trim())
+
+  const latitude = Number(latitudeRaw)
+  const longitude = Number(longitudeRaw)
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || !districtRaw || !addressRaw) {
+    return null
+  }
+
+  return {
+    latitude,
+    longitude,
+    district: districtRaw,
+    address: addressRaw,
+  }
+}
+
+const rawFixedLocation = getEnv('VITE_FIXED_LOCATION').trim()
+const normalizedFixedLocation = rawFixedLocation.toLowerCase()
+const fallbackAppLocation =
+  parseConfiguredLocation(DEFAULT_APP_LOCATION_VALUE) ??
+  ({
+    latitude: 37.3947,
+    longitude: 127.1112,
+    district: '\uD310\uAD50\uC5ED',
+    address: '\uACBD\uAE30\uB3C4 \uC131\uB0A8\uC2DC \uBD84\uB2F9\uAD6C \uD310\uAD50\uC5ED',
+  } satisfies ConfiguredAppLocation)
+const configuredFixedLocation =
+  rawFixedLocation && normalizedFixedLocation !== FIXED_LOCATION_OFF_VALUE
+    ? parseConfiguredLocation(rawFixedLocation)
+    : null
 
 export const APP_ENV = getEnv('VITE_APP_ENV', 'development') as AppEnv
 
@@ -46,3 +91,8 @@ export const ACTIVITY_DEBUG = getBooleanEnv('VITE_ACTIVITY_DEBUG', false)
 
 export const SENTRY_DSN = getEnv('VITE_SENTRY_DSN')
 export const SENTRY_ENABLED = getBooleanEnv('VITE_SENTRY_ENABLED', APP_ENV !== 'development')
+
+export const DEFAULT_APP_LOCATION = configuredFixedLocation ?? fallbackAppLocation
+export const FIXED_APP_LOCATION =
+  normalizedFixedLocation === FIXED_LOCATION_OFF_VALUE ? null : DEFAULT_APP_LOCATION
+export const IS_FIXED_LOCATION_ENABLED = FIXED_APP_LOCATION !== null

--- a/src/shared/lib/geolocation.ts
+++ b/src/shared/lib/geolocation.ts
@@ -1,3 +1,5 @@
+import { FIXED_APP_LOCATION, IS_FIXED_LOCATION_ENABLED } from '@/shared/config/env'
+
 const STORAGE_KEY = 'location_permission_granted'
 
 export type GeoPosition = {
@@ -8,6 +10,7 @@ export type GeoPosition = {
 export type GeolocationPermissionState = 'granted' | 'denied' | 'prompt' | 'unknown'
 
 export const getLocationPermission = (): boolean => {
+  if (IS_FIXED_LOCATION_ENABLED) return true
   return localStorage.getItem(STORAGE_KEY) === 'true'
 }
 
@@ -16,6 +19,7 @@ export const setLocationPermission = (granted: boolean) => {
 }
 
 export const getGeolocationPermissionState = async (): Promise<GeolocationPermissionState> => {
+  if (IS_FIXED_LOCATION_ENABLED) return 'granted'
   if (typeof navigator === 'undefined') return 'unknown'
 
   try {
@@ -35,6 +39,11 @@ export const getGeolocationPermissionState = async (): Promise<GeolocationPermis
 
 export const requestLocationPermission = (): Promise<boolean> => {
   return new Promise((resolve) => {
+    if (IS_FIXED_LOCATION_ENABLED) {
+      resolve(true)
+      return
+    }
+
     if (!navigator.geolocation) {
       setLocationPermission(false)
       resolve(false)
@@ -59,6 +68,14 @@ const truncateCoord = (coord: number): number => Math.floor(coord * 10000) / 100
 
 export const getCurrentPosition = (): Promise<GeoPosition | null> => {
   return new Promise((resolve) => {
+    if (IS_FIXED_LOCATION_ENABLED && FIXED_APP_LOCATION) {
+      resolve({
+        latitude: truncateCoord(FIXED_APP_LOCATION.latitude),
+        longitude: truncateCoord(FIXED_APP_LOCATION.longitude),
+      })
+      return
+    }
+
     if (!navigator.geolocation) {
       resolve(null)
       return


### PR DESCRIPTION
## Summary
- `VITE_FIXED_LOCATION` 환경 변수로 고정 위치를 설정할 수 있도록 추가했습니다.
- 값이 비어 있거나 없을 때는 판교를 기본 고정 위치로 사용하고, `off`면 실제 기기 위치를 사용하도록 정리했습니다.
- geolocation, LocationProvider, 홈/오늘점심/부트스트랩의 위치 fallback을 공통 설정으로 통합했습니다.
- `.env.example`에 설정 형식을 문서화했습니다.

## Related Issue
- close #282

## Testing
- `node .\\node_modules\\typescript\\bin\\tsc -b`
- `node .\\node_modules\\eslint\\bin\\eslint.js --fix src\\shared\\config\\env.ts src\\shared\\lib\\geolocation.ts src\\entities\\location\\model\\LocationProvider.tsx src\\app\\bootstrap\\bootstrap.ts src\\pages\\home\\HomePage.tsx src\\pages\\today-lunch\\TodayLunchPage.tsx`
- `node .\\node_modules\\prettier\\bin\\prettier.cjs --write src\\shared\\config\\env.ts src\\shared\\lib\\geolocation.ts src\\entities\\location\\model\\LocationProvider.tsx src\\app\\bootstrap\\bootstrap.ts src\\pages\\home\\HomePage.tsx src\\pages\\today-lunch\\TodayLunchPage.tsx`

## Notes
- 로컬 환경의 Rollup optional dependency 누락으로 `vite build`는 실행하지 못했습니다.